### PR TITLE
avoid network errors when envVars are not set, fallback to console

### DIFF
--- a/__tests__/log.test.ts
+++ b/__tests__/log.test.ts
@@ -1,6 +1,8 @@
 /**
  * @jest-environment jsdom
  */
+// set axiom env vars before importing logger
+process.env.AXIOM_INGEST_ENDPOINT = 'https://example.co/api/test';
 import { log } from '../src/logger';
 
 global.fetch = jest.fn() as jest.Mock;

--- a/__tests__/noEnvVars.test.ts
+++ b/__tests__/noEnvVars.test.ts
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// clear Axiom env vars
+process.env.AXIOM_INGEST_ENDPOINT = '';
+process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT = '';
+import { NextWebVitalsMetric } from 'next/app';
+import { log } from '../src/logger';
+import { reportWebVitals } from '../src/webVitals';
+
+global.fetch = jest.fn() as jest.Mock;
+const mockedLog = jest.spyOn(global.console, 'log').mockImplementation();
+
+test('sending logs on localhost should fallback to console', () => {
+  log.info('hello, world!');
+  jest.advanceTimersByTime(1000);
+  expect(fetch).toHaveBeenCalledTimes(0);
+  expect(mockedLog).toHaveBeenCalledTimes(1);
+});
+
+test('webVitals should not be sent when envVars are not set', () => {
+  const metric: NextWebVitalsMetric = { id: '1', startTime: 1234, value: 1, name: 'FCP', label: 'web-vital' };
+  reportWebVitals(metric);
+  jest.advanceTimersByTime(1000);
+  expect(fetch).toHaveBeenCalledTimes(0);
+});

--- a/__tests__/webvitals.test.ts
+++ b/__tests__/webvitals.test.ts
@@ -4,6 +4,8 @@
 
 import { jest } from '@jest/globals';
 import { NextWebVitalsMetric } from 'next/app';
+// set axiom env vars before importing webvitals
+process.env.AXIOM_INGEST_ENDPOINT = 'https://example.co/api/test';
 import { reportWebVitals } from '../src/webVitals';
 
 global.fetch = jest.fn() as jest.Mock;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,11 @@ export function withAxiom(nextConfig: NextConfig): NextConfig {
       const webVitalsEndpoint = getIngestURL(EndpointType.webVitals);
       const logsEndpoint = getIngestURL(EndpointType.logs);
       if (!webVitalsEndpoint && !logsEndpoint) {
+        console.warn(
+          'axiom - Envvars not detected. If this is production please see https://github.com/axiomhq/next-axiom for help'
+        );
+        console.warn('axiom - Sending Web Vitals to /dev/null');
+        console.warn('axiom - Sending logs to console');
         return rewrites || []; // nothing to do
       }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,13 +1,16 @@
-import { proxyPath, isBrowser, EndpointType, getIngestURL, isVercel } from './shared';
+import { proxyPath, isBrowser, EndpointType, getIngestURL, isVercel, isEnvVarsSet } from './shared';
 import { throttle } from './shared';
 
 const url = isBrowser ? `${proxyPath}/logs` : getIngestURL(EndpointType.logs);
+
 const throttledSendLogs = throttle(sendLogs, 1000);
 let logEvents: any[] = [];
 
 function _log(level: string, message: string, args: any = {}) {
-  if (!url) {
-    console.warn('axiom: NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT is not defined');
+  if (!isEnvVarsSet) {
+    // if AXIOM ingesting url is not set, fallback to printing to console
+    // to avoid network errors in development environments
+    console.log(`info - ${message}\n`, args);
     return;
   }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,6 +1,7 @@
 export const proxyPath = '/_axiom';
 
 export const isBrowser = typeof window !== 'undefined';
+export const isEnvVarsSet = process.env.AXIOM_INGEST_ENDPOINT || process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT;
 export const isVercel =
   typeof process.env.NEXT_PUBLIC_VERCEL_ENV != 'undefined' && process.env.NEXT_PUBLIC_VERCEL_ENV != '';
 

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -1,5 +1,5 @@
 import { NextWebVitalsMetric } from 'next/app';
-import { isBrowser, proxyPath } from './shared';
+import { isBrowser, proxyPath, isEnvVarsSet } from './shared';
 import { throttle } from './shared';
 
 export { log } from './logger';
@@ -13,6 +13,11 @@ let collectedMetrics: WebVitalsMetric[] = [];
 
 export function reportWebVitals(metric: NextWebVitalsMetric) {
   collectedMetrics.push({ route: window.__NEXT_DATA__?.page, ...metric });
+  // if Axiom env vars are not set, do nothing,
+  // otherwise devs will get errors on dev environments
+  if (!isEnvVarsSet) {
+    return;
+  }
   throttledSendMetrics();
 }
 


### PR DESCRIPTION
Developers get network errors on dev/localhost envs because
Axiom ingest endpoint variable is not set. This commit prevents
sending requests when those env vars are not set. It fallsback to
just print to console for logging.