### PR TITLE
Support attaching fields to an intermediate logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,25 @@ log.warn('be careful!')
 log.error('oops!')
 ```
 
+If you have fields you want to log with all messages, you can create an 
+intermediate logger like this:
+```js
+const logger = log.with({ scope: 'user' })
+logger.info('User logged in', { userId: 42 })
+// { 
+//   "level": "info", 
+//   "_time": "2022-07-04T09:49:42Z", 
+//   "message": "User logged in", 
+//   "fields": {
+//     "scope": "user",
+//     "userId": 42,
+//   }
+// }
+```
+
 4. Deploy your site and watch data coming into your Axiom dataset.
+
+> **Note**: Logs are only sent to Axiom from production deployments.
 
 ### Configuration
 

--- a/__tests__/log.test.ts
+++ b/__tests__/log.test.ts
@@ -5,10 +5,11 @@
 process.env.AXIOM_INGEST_ENDPOINT = 'https://example.co/api/test';
 import { log } from '../src/logger';
 
-global.fetch = jest.fn() as jest.Mock;
 jest.useFakeTimers();
 
 test('sending logs from browser', async () => {
+  global.fetch = jest.fn() as jest.Mock;
+
   log.info('hello, world!');
   expect(fetch).toHaveBeenCalledTimes(0);
 
@@ -20,4 +21,22 @@ test('sending logs from browser', async () => {
 
   await log.flush();
   expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test('with', async () => {
+  global.fetch = jest.fn() as jest.Mock;
+
+  const logger = log.with({ foo: 'bar' });
+  logger.info('hello, world!', { bar: 'baz' });
+  expect(fetch).toHaveBeenCalledTimes(0);
+
+  jest.advanceTimersByTime(1000);
+  expect(fetch).toHaveBeenCalledTimes(1);
+  const payload = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+  expect(payload.length).toBe(1);
+  const fst = payload[0];
+  expect(fst.level).toBe('info');
+  expect(fst.message).toBe('hello, world!');
+  expect(fst.fields.foo).toBe('bar');
+  expect(fst.fields.bar).toBe('baz');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -27,8 +27,30 @@ export const log = {
   info: (message: string, args: any = {}) => _log('info', message, args),
   warn: (message: string, args: any = {}) => _log('warn', message, args),
   error: (message: string, args: any = {}) => _log('error', message, args),
+  with: (args: any) => new Logger(args),
   flush: sendLogs,
 };
+
+class Logger {
+  args: any = {};
+
+  constructor(args: any = {}) {
+    this.args = args;
+  }
+
+  debug(message: string, args: any = {}) {
+    _log('debug', message, { ...this.args, ...args });
+  }
+  info(message: string, args: any = {}) {
+    _log('info', message, { ...this.args, ...args });
+  }
+  warn(message: string, args: any = {}) {
+    _log('warn', message, { ...this.args, ...args });
+  }
+  error(message: string, args: any = {}) {
+    _log('error', message, { ...this.args, ...args });
+  }
+}
 
 async function sendLogs() {
   if (!logEvents.length) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -50,6 +50,10 @@ class Logger {
   error(message: string, args: any = {}) {
     _log('error', message, { ...this.args, ...args });
   }
+
+  with(args: any) {
+    return new Logger({ ...this.args, ...args });
+  }
 }
 
 async function sendLogs() {


### PR DESCRIPTION
If you have fields you want to log with all messages, you can create an 
intermediate logger like this:
```js
const logger = log.with({ scope: 'user' })
logger.info('User logged in', { userId: 42 })
// { 
//   "level": "info", 
//   "_time": "2022-07-04T09:49:42Z", 
//   "message": "User logged in", 
//   "fields": {
//     "scope": "user",
//     "userId": 42,
//   }
// }
```