### PR TITLE
fix/#29: set basePath to false in rewritres

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -2,6 +2,7 @@ import { NextConfig, NextApiHandler, NextApiResponse } from 'next';
 import { NextMiddleware } from 'next/server';
 import { proxyPath, EndpointType, getIngestURL } from './shared';
 import { log } from './logger';
+import { Rewrite } from 'next/dist/lib/load-custom-routes';
 
 declare global {
   var EdgeRuntime: string;
@@ -36,14 +37,16 @@ function withAxiomNextConfig(nextConfig: NextConfig): NextConfig {
         return rewrites || []; // nothing to do
       }
 
-      const axiomRewrites = [
+      const axiomRewrites: Rewrite[] = [
         {
           source: `${proxyPath}/web-vitals`,
           destination: webVitalsEndpoint,
+          basePath: false,
         },
         {
           source: `${proxyPath}/logs`,
           destination: logsEndpoint,
+          basePath: false,
         },
       ];
 


### PR DESCRIPTION
(#29): logs and webvitals are not working when nextjs basePath is set.
As a solution for this, we would set basePath to false in our rewrites
so it would be able to rewrite the axiom endpoints without appending
the basePath as part of the rewrite.