### PR TITLE
set source as part of vercel information object

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -37,13 +37,19 @@ interface VercelData {
   environment?: string;
   region?: string;
   route?: string;
+  source?: string;
 }
 
 export class Logger {
   public logEvents: LogEvent[] = [];
   throttledSendLogs = throttle(this.sendLogs, 1000);
 
-  constructor(private args: any = {}, private req: RequestReport | null = null, private autoFlush: Boolean = true) {}
+  constructor(
+    private args: any = {},
+    private req: RequestReport | null = null,
+    private autoFlush: Boolean = true,
+    public source: 'frontend' | 'lambda' | 'edge' = 'frontend'
+  ) {}
 
   debug(message: string, args: any = {}) {
     this._log('debug', message, { ...this.args, ...args });
@@ -59,11 +65,11 @@ export class Logger {
   }
 
   with(args: any) {
-    return new Logger({ ...this.args, ...args }, this.req, this.autoFlush);
+    return new Logger({ ...this.args, ...args }, this.req, this.autoFlush, this.source);
   }
 
   withRequest(req: RequestReport) {
-    return new Logger({ ...this.args }, req, this.autoFlush);
+    return new Logger({ ...this.args }, req, this.autoFlush, this.source);
   }
 
   _log(level: string, message: string, args: any = {}) {
@@ -75,6 +81,7 @@ export class Logger {
     logEvent.vercel = {
       environment: vercelEnv,
       region: vercelRegion,
+      source: this.source,
     };
 
     if (this.req != null) {

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -113,7 +113,7 @@ function withAxiomNextApiHandler(handler: NextApiHandler): NextApiHandler {
       ip: getHeaderOrDefault(req, 'x-forwarded-for', ''),
       region: vercelRegion,
     };
-    const logger = new Logger({}, report, false);
+    const logger = new Logger({}, report, false, 'lambda');
     const axiomRequest = req as AxiomAPIRequest;
     axiomRequest.log = logger;
     const [wrappedRes, allPromises] = interceptNextApiResponse(axiomRequest, res);
@@ -151,7 +151,7 @@ function withAxiomNextEdgeFunction(handler: NextMiddleware): NextMiddleware {
       userAgent: req.headers.get('user-agent'),
     };
 
-    const logger = new Logger({}, report, false);
+    const logger = new Logger({}, report, false, 'edge');
     const axiomRequest = req as AxiomRequest;
     axiomRequest.log = logger;
 


### PR DESCRIPTION
we want to know whether the ingested logs are being sent
from frontend, lambda function or edge function. Setting the source
as part of the logs payload would allow us in the backend to read it
and set it in the ingested logs.