### PR TITLE
handle non-object arguments

### DIFF
--- a/__tests__/log.test.ts
+++ b/__tests__/log.test.ts
@@ -40,3 +40,22 @@ test('with', async () => {
   expect(fst.fields.foo).toBe('bar');
   expect(fst.fields.bar).toBe('baz');
 });
+
+test('passing non-object', async () => {
+  global.fetch = jest.fn() as jest.Mock;
+
+  const logger = log.with({ foo: 'bar' });
+  logger.info('hello, world!', 'baz');
+  expect(fetch).toHaveBeenCalledTimes(0);
+
+  jest.advanceTimersByTime(1000);
+  expect(fetch).toHaveBeenCalledTimes(1);
+  const payload = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+  expect(payload.length).toBe(1);
+  const fst = payload[0];
+  expect(fst.level).toBe('info');
+  expect(fst.message).toBe('hello, world!');
+  expect(fst.fields.foo).toBe('bar');
+  console.log(fst.fields);
+  expect(fst.fields.args).toBe('baz');
+});

--- a/__tests__/log.test.ts
+++ b/__tests__/log.test.ts
@@ -45,7 +45,8 @@ test('passing non-object', async () => {
   global.fetch = jest.fn() as jest.Mock;
 
   const logger = log.with({ foo: 'bar' });
-  logger.info('hello, world!', 'baz');
+  const args = 'baz';
+  logger.info('hello, world!', args as unknown as object);
   expect(fetch).toHaveBeenCalledTimes(0);
 
   jest.advanceTimersByTime(1000);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -52,16 +52,16 @@ export class Logger {
   ) {}
 
   debug = (message: string, args: any = {}) => {
-    this._log('debug', message, { ...this.args, ...args });
+    this._log('debug', message, args);
   };
   info = (message: string, args: any = {}) => {
-    this._log('info', message, { ...this.args, ...args });
+    this._log('info', message, args);
   };
   warn = (message: string, args: any = {}) => {
-    this._log('warn', message, { ...this.args, ...args });
+    this._log('warn', message, args);
   };
   error = (message: string, args: any = {}) => {
-    this._log('error', message, { ...this.args, ...args });
+    this._log('error', message, args);
   };
 
   with = (args: any) => {
@@ -74,8 +74,11 @@ export class Logger {
 
   _log = (level: string, message: string, args: any = {}) => {
     const logEvent: LogEvent = { level, message, _time: new Date(Date.now()).toISOString(), fields: {} };
-    if (Object.keys(args).length > 0) {
-      logEvent.fields = args;
+    // check if passed args is an object, if its not an object, add it to fields.args
+    if (typeof args === 'object' && args !== null && Object.keys(args).length > 0) {
+      logEvent.fields = { ...this.args, ...args };
+    } else if (args != null) {
+      logEvent.fields = { ...this.args, args: args };
     }
 
     logEvent.vercel = {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -45,26 +45,26 @@ export class Logger {
   throttledSendLogs = throttle(this.sendLogs, 1000);
 
   constructor(
-    private args: any = {},
+    private args: { [key: string]: any } = {},
     private req: RequestReport | null = null,
     private autoFlush: Boolean = true,
     public source: 'frontend' | 'lambda' | 'edge' = 'frontend'
   ) {}
 
-  debug = (message: string, args: any = {}) => {
+  debug = (message: string, args: { [key: string]: any } = {}) => {
     this._log('debug', message, args);
   };
-  info = (message: string, args: any = {}) => {
+  info = (message: string, args: { [key: string]: any } = {}) => {
     this._log('info', message, args);
   };
-  warn = (message: string, args: any = {}) => {
+  warn = (message: string, args: { [key: string]: any } = {}) => {
     this._log('warn', message, args);
   };
-  error = (message: string, args: any = {}) => {
+  error = (message: string, args: { [key: string]: any } = {}) => {
     this._log('error', message, args);
   };
 
-  with = (args: any) => {
+  with = (args: { [key: string]: any }) => {
     return new Logger({ ...this.args, ...args }, this.req, this.autoFlush, this.source);
   };
 
@@ -72,7 +72,7 @@ export class Logger {
     return new Logger({ ...this.args }, req, this.autoFlush, this.source);
   };
 
-  _log = (level: string, message: string, args: any = {}) => {
+  _log = (level: string, message: string, args: { [key: string]: any } = {}) => {
     const logEvent: LogEvent = { level, message, _time: new Date(Date.now()).toISOString(), fields: {} };
     // check if passed args is an object, if its not an object, add it to fields.args
     if (typeof args === 'object' && args !== null && Object.keys(args).length > 0) {


### PR DESCRIPTION
when arguments are spread like this `...args` it automatically converts to an objects, and then we lose the value. 
for example:
```
log.info('foo', 'bar') 
```
would result in `args = {0: 'b', 1: 'a', 2: 'r'}`

This PR, handles the arguments in the `_log` method and checks if its an object or not, if the passed args is not an object, it will be stored in `fields.args` as it is.