### PR TITLE
catch and swallow exceptions on fetch

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -151,18 +151,23 @@ export class Logger {
     }
     const reqOptions: RequestInit = { body, method, keepalive, headers };
 
+    function sendFallback() {
+      // Do not leak network errors; does not affect the running app
+      fetch(url, reqOptions).catch(console.error);
+    }
+
     try {
       if (typeof fetch === 'undefined') {
         const fetch = await require('whatwg-fetch');
-        await fetch(url, reqOptions);
+        fetch(url, reqOptions).catch(console.error);
       } else if (config.isBrowser && isVercel && navigator.sendBeacon) {
         // sendBeacon fails if message size is greater than 64kb, so
         // we fall back to fetch.
         if (!navigator.sendBeacon(url, body)) {
-          await fetch(url, reqOptions);
+          sendFallback()
         }
       } else {
-        await fetch(url, reqOptions);
+        sendFallback()
       }
     } catch (e) {
       console.error(`Failed to send logs to Axiom: ${e}`);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -164,10 +164,10 @@ export class Logger {
         // sendBeacon fails if message size is greater than 64kb, so
         // we fall back to fetch.
         if (!navigator.sendBeacon(url, body)) {
-          sendFallback()
+          sendFallback();
         }
       } else {
-        sendFallback()
+        sendFallback();
       }
     } catch (e) {
       console.error(`Failed to send logs to Axiom: ${e}`);


### PR DESCRIPTION
while sending logs exceptions could happend, swallowing the exception ensures we don't interrupts customer apps or break api functions responses. We do the same in web-vitals. I am not sure though about removing await, need to think about it and do some testing.