### PR TITLE
Utilize console logs for log drains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - "v*"
 
 jobs:
-  check-format:
+  lint:
     name: Check format
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 17
       - run: npm install
-      - run: npm run check-format
+      - run: npm run lint
   unittests:
     name: Check Tests
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
   publish:
     name: Publish
     needs: 
-      - check-format
+      - lint
       - build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ You can also disable logging completely by setting the log level to `off`:
 export AXIOM_LOG_LEVEL=off
 ```
 
+### Performance notes
+
+- The `withAxiom` wrapper that is used with the server-side code utilizes fetch to make requests
+  to axiom, the fetch uses `keep-alive` to ensure delivery of logs. If this hurts the execution
+  time of your serverless functioncs, you can switch to using the Axiom+Vercel integration, the log
+  drain will send the logs to axiom, but there is a [limit of 4KB per log output](https://vercel.com/docs/concepts/limits/overview#logs).
+
+  to enable such functionality export the following environment variable:
+
+  ```sh
+  export ENABLE_AXIOM_LOG_DRAIN=true
+  ```
+
 ### License
 
 Distributed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ export const getServerSideProps = withAxiomGetServerSideProps(async ({ req, log 
 - The `withAxiom` wrapper that is used with the server-side code utilizes fetch to make requests
   to axiom, the fetch uses `keep-alive` to ensure delivery of logs. If this hurts the execution
   time of your serverless functioncs, you can switch to using the Axiom+Vercel integration, the log
-  drain will send the logs to axiom, but there is a [limit of 4KB per log output](https://vercel.com/docs/concepts/limits/overview#logs).
+  drain will send the logs to axiom, but there is a [limit of 4KB per log output](https://vercel.com/docs/concepts/limits/overview#logs) and it won't have the full metadata.
 
   to enable such functionality export the following environment variable:
 

--- a/__tests__/log.test.ts
+++ b/__tests__/log.test.ts
@@ -8,6 +8,10 @@ import { log } from '../src/logger';
 
 const mockedLog = jest.spyOn(global.console, 'log').mockImplementation();
 
+afterEach(() => {
+  mockedLog.mockClear();
+});
+
 const getMockCallDetails = (mockedLog: jest.SpyInstance, callIndex = 0) => {
   const payload = (mockedLog as jest.Mock).mock.calls[callIndex];
   const level = payload[2];
@@ -28,8 +32,6 @@ test('with() should create child logger', async () => {
   expect(Object.keys(fields).length).toBe(2);
   expect(fields.foo).toBe('bar');
   expect(fields.bar).toBe('baz');
-
-  mockedLog.mockClear();
 });
 
 test('passing non-object should be wrapped in object', async () => {
@@ -43,8 +45,6 @@ test('passing non-object should be wrapped in object', async () => {
   expect(msg).toBe('hello, world!');
   expect(fields.foo).toBe('bar');
   expect(fields.args).toBe('baz');
-
-  mockedLog.mockClear();
 });
 
 test('flushing parent logger should flush children', async () => {
@@ -70,9 +70,6 @@ test('flushing parent logger should flush children', async () => {
   // ensure there is nothing was left unflushed
   await log.flush();
   expect(mockedLog).toHaveBeenCalledTimes(3);
-
-  // console.log(mockedFlush.mock.calls)
-  mockedLog.mockClear();
 });
 
 test('throwing exception should be handled as error object', async () => {
@@ -83,6 +80,4 @@ test('throwing exception should be handled as error object', async () => {
   expect(Object.keys(fields).length).toEqual(3); // { name, message, stack }
   expect(fields.message).toEqual(err.message);
   expect(fields.name).toEqual(err.name);
-
-  mockedLog.mockClear();
 });

--- a/__tests__/logLevels.test.ts
+++ b/__tests__/logLevels.test.ts
@@ -17,37 +17,37 @@ test('log levels', async () => {
   expect(mockedLog).toHaveBeenCalledTimes(0);
 
   // test overriding log level per logger
-  let logger = new Logger({}, null, false, 'frontend', 'error');
+  let logger = new Logger({}, null, 'frontend', 'error');
   logger.debug('hello');
   logger.info('hello');
   logger.warn('hello');
   await logger.flush();
   expect(mockedLog).toHaveBeenCalledTimes(0);
 
-  logger = new Logger({}, null, false, 'frontend', 'warn');
+  logger = new Logger({}, null, 'frontend', 'warn');
   logger.info('hello');
   logger.debug('hello');
   await logger.flush();
   expect(mockedLog).toHaveBeenCalledTimes(0);
 
-  logger = new Logger({}, null, false, 'frontend', 'info');
+  logger = new Logger({}, null, 'frontend', 'info');
   logger.debug('hello');
   await logger.flush();
   expect(mockedLog).toHaveBeenCalledTimes(0);
 
   // disabled logging
-  logger = new Logger({}, null, false, 'frontend', 'off');
+  logger = new Logger({}, null, 'frontend', 'off');
   logger.error('no logs');
   await logger.flush();
   expect(mockedLog).toHaveBeenCalledTimes(0);
 
-  logger = new Logger({}, null, false, 'frontend', 'error');
+  logger = new Logger({}, null, 'frontend', 'error');
   logger.warn('warn');
   logger.error('error');
   await logger.flush();
   expect(mockedLog).toHaveBeenCalledTimes(1);
 
-  logger = new Logger({}, null, false, 'frontend', 'debug');
+  logger = new Logger({}, null, 'frontend', 'debug');
   logger.warn('hello');
   await logger.flush();
   expect(mockedLog).toHaveBeenCalledTimes(2);

--- a/__tests__/logLevels.test.ts
+++ b/__tests__/logLevels.test.ts
@@ -1,19 +1,20 @@
-/**
- * @jest-environment jsdom
- */
-// set axiom env vars before importing logger
-process.env.AXIOM_INGEST_ENDPOINT = 'https://example.co/api/test';
+// clear axiom env vars before importing logger
+process.env.AXIOM_TOKEN = '';
+process.env.AXIOM_INGEST_ENDPOINT = '';
 process.env.AXIOM_LOG_LEVEL = 'error';
+import config from '../src/config';
 import { log, Logger } from '../src/logger';
+import ConsoleTransport from '../src/transports/console.transport';
 
 jest.useFakeTimers();
 
 test('log levels', async () => {
-  global.fetch = jest.fn() as jest.Mock;
+  const mockedLog = jest.spyOn(ConsoleTransport.prototype, 'log').mockImplementation();
+  expect(config.isEnvVarsSet()).toBe(false);
 
   log.info('test');
   await log.flush();
-  expect(fetch).toHaveBeenCalledTimes(0);
+  expect(mockedLog).toHaveBeenCalledTimes(0);
 
   // test overriding log level per logger
   let logger = new Logger({}, null, false, 'frontend', 'error');
@@ -21,33 +22,33 @@ test('log levels', async () => {
   logger.info('hello');
   logger.warn('hello');
   await logger.flush();
-  expect(fetch).toHaveBeenCalledTimes(0);
+  expect(mockedLog).toHaveBeenCalledTimes(0);
 
   logger = new Logger({}, null, false, 'frontend', 'warn');
   logger.info('hello');
   logger.debug('hello');
   await logger.flush();
-  expect(fetch).toHaveBeenCalledTimes(0);
+  expect(mockedLog).toHaveBeenCalledTimes(0);
 
   logger = new Logger({}, null, false, 'frontend', 'info');
   logger.debug('hello');
   await logger.flush();
-  expect(fetch).toHaveBeenCalledTimes(0);
+  expect(mockedLog).toHaveBeenCalledTimes(0);
 
   // disabled logging
   logger = new Logger({}, null, false, 'frontend', 'off');
   logger.error('no logs');
   await logger.flush();
-  expect(fetch).toHaveBeenCalledTimes(0);
+  expect(mockedLog).toHaveBeenCalledTimes(0);
 
   logger = new Logger({}, null, false, 'frontend', 'error');
   logger.warn('warn');
   logger.error('error');
   await logger.flush();
-  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(mockedLog).toHaveBeenCalledTimes(1);
 
   logger = new Logger({}, null, false, 'frontend', 'debug');
   logger.warn('hello');
   await logger.flush();
-  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(mockedLog).toHaveBeenCalledTimes(2);
 });

--- a/__tests__/noEnvVars.test.ts
+++ b/__tests__/noEnvVars.test.ts
@@ -9,13 +9,20 @@ process.env.AXIOM_INGEST_ENDPOINT = '';
 process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT = '';
 import { NextWebVitalsMetric } from 'next/app';
 import { log } from '../src/logger';
+import ConsoleTransport from '../src/transports/console.transport';
 import { reportWebVitals } from '../src/webVitals';
 
 jest.useFakeTimers();
 global.fetch = jest.fn() as jest.Mock;
 const mockedLog = jest.spyOn(global.console, 'log').mockImplementation();
 
+afterEach(() => {
+  mockedLog.mockClear();
+  (global.fetch as jest.Mock).mockClear();
+});
+
 test('sending logs on localhost should fallback to console', () => {
+  expect(log.transport instanceof ConsoleTransport).toBe(true);
   log.info('hello, world!');
   jest.advanceTimersByTime(1000);
   expect(mockedLog).toHaveBeenCalledTimes(1);
@@ -26,6 +33,6 @@ test('webVitals should not be sent when envVars are not set', () => {
   const metric: NextWebVitalsMetric = { id: '1', startTime: 1234, value: 1, name: 'FCP', label: 'web-vital' };
   reportWebVitals(metric);
   jest.advanceTimersByTime(1000);
-  expect(mockedLog).toHaveBeenCalledTimes(1);
+  expect(mockedLog).toHaveBeenCalledTimes(0);
   expect(fetch).toHaveBeenCalledTimes(0);
 });

--- a/__tests__/noEnvVars.test.ts
+++ b/__tests__/noEnvVars.test.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-
 // clear Axiom env vars
 process.env.AXIOM_URL = '';
 process.env.AXIOM_DATASET = '';
@@ -19,13 +18,14 @@ const mockedLog = jest.spyOn(global.console, 'log').mockImplementation();
 test('sending logs on localhost should fallback to console', () => {
   log.info('hello, world!');
   jest.advanceTimersByTime(1000);
-  expect(fetch).toHaveBeenCalledTimes(0);
   expect(mockedLog).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenCalledTimes(0);
 });
 
 test('webVitals should not be sent when envVars are not set', () => {
   const metric: NextWebVitalsMetric = { id: '1', startTime: 1234, value: 1, name: 'FCP', label: 'web-vital' };
   reportWebVitals(metric);
   jest.advanceTimersByTime(1000);
+  expect(mockedLog).toHaveBeenCalledTimes(1);
   expect(fetch).toHaveBeenCalledTimes(0);
 });

--- a/__tests__/transports/console-transport.spec.ts
+++ b/__tests__/transports/console-transport.spec.ts
@@ -1,0 +1,9 @@
+import ConsoleTransport from "../../src/transports/console.transport";
+
+const mockedLog = jest.spyOn(global.console, 'log').mockImplementation();
+
+test('ConsoleTransport should print to console immediately', () => {
+    const transport = new ConsoleTransport();
+    transport.log({ _time: Date.now().toString(), level: 'info', message: 'hello, world!', fields: {} });
+    expect(mockedLog).toHaveBeenCalledTimes(1);
+});

--- a/__tests__/transports/fetch-transport.spec.ts
+++ b/__tests__/transports/fetch-transport.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { jest } from '@jest/globals';
+import 'whatwg-fetch';
 // set axiom env vars before importing logger
 process.env.AXIOM_INGEST_ENDPOINT = 'https://example.co/api/test';
 global.fetch = jest.fn(() => Promise.resolve(new Response('', { status: 204, statusText: 'OK' }))) as jest.Mock;
@@ -21,8 +22,6 @@ test('FetchTransport should throttle logs & send using fetch', () => {
 });
 
 test('sending logs from browser should be throttled', async () => {
-  global.fetch = jest.fn() as jest.Mock;
-
   log.info('hello, world!');
   expect(fetch).toHaveBeenCalledTimes(0);
 
@@ -37,8 +36,6 @@ test('sending logs from browser should be throttled', async () => {
 });
 
 test('flushing parent logger should flush children', async () => {
-    global.fetch = jest.fn() as jest.Mock;
-
     log.info('hello, world!');
     const logger1 = log.with({ foo: 'bar' });
     logger1.debug('logger1');
@@ -49,8 +46,8 @@ test('flushing parent logger should flush children', async () => {
   
     expect(fetch).toHaveBeenCalledTimes(3);
   
-    const payload = (fetch as jest.Mock).mock.calls[0][1].body;
-    const firstLog = JSON.parse(payload);
+    const payload = (fetch as jest.Mock).mock.calls[2][1];
+    const firstLog = JSON.parse(payload.body)[0];
     expect(Object.keys(firstLog.fields).length).toEqual(2);
     expect(firstLog.fields.foo).toEqual('bar');
     expect(firstLog.fields.bar).toEqual('foo');

--- a/__tests__/transports/fetch-transport.spec.ts
+++ b/__tests__/transports/fetch-transport.spec.ts
@@ -12,7 +12,12 @@ import FetchTransport from '../../src/transports/fetch.transport';
 jest.useFakeTimers();
 const mockedConsoleLog = jest.spyOn(global.console, 'log').mockImplementation(() => {});
 
+afterEach(() => {
+  (global.fetch as jest.Mock).mockClear();
+})
+
 test('FetchTransport should throttle logs & send using fetch', () => {
+  (global.fetch as jest.Mock).mockClear();
   const transport = new FetchTransport();
   transport.log({ _time: Date.now().toString(), level: 'info', message: 'hello, world!', fields: {} });
   expect(mockedConsoleLog).toHaveBeenCalledTimes(0);
@@ -23,6 +28,7 @@ test('FetchTransport should throttle logs & send using fetch', () => {
 
 test('sending logs from browser should be throttled', async () => {
   log.info('hello, world!');
+  expect(log.transport instanceof FetchTransport).toBe(true);
   expect(fetch).toHaveBeenCalledTimes(0);
 
   jest.advanceTimersByTime(1000);

--- a/__tests__/transports/fetch-transport.spec.ts
+++ b/__tests__/transports/fetch-transport.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+// set axiom env vars before importing logger
+process.env.AXIOM_INGEST_ENDPOINT = 'https://example.co/api/test';
+global.fetch = jest.fn(() => Promise.resolve(new Response('', { status: 204, statusText: 'OK' }))) as jest.Mock;
+import { log } from '../../src/logger';
+import FetchTransport from '../../src/transports/fetch.transport';
+
+jest.useFakeTimers();
+const mockedConsoleLog = jest.spyOn(global.console, 'log').mockImplementation(() => {});
+
+test('FetchTransport should throttle logs & send using fetch', () => {
+  const transport = new FetchTransport();
+  transport.log({ _time: Date.now().toString(), level: 'info', message: 'hello, world!', fields: {} });
+  expect(mockedConsoleLog).toHaveBeenCalledTimes(0);
+  expect(fetch).toHaveBeenCalledTimes(0);
+  jest.advanceTimersByTime(1000);
+  expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test('sending logs from browser should be throttled', async () => {
+  global.fetch = jest.fn() as jest.Mock;
+
+  log.info('hello, world!');
+  expect(fetch).toHaveBeenCalledTimes(0);
+
+  jest.advanceTimersByTime(1000);
+  expect(fetch).toHaveBeenCalledTimes(1);
+
+  log.info('hello, world!');
+  expect(fetch).toHaveBeenCalledTimes(1);
+
+  await log.flush();
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test('flushing parent logger should flush children', async () => {
+    global.fetch = jest.fn() as jest.Mock;
+
+    log.info('hello, world!');
+    const logger1 = log.with({ foo: 'bar' });
+    logger1.debug('logger1');
+    const logger2 = logger1.with({ bar: 'foo' });
+    logger2.debug('logger2');
+    expect(fetch).toHaveBeenCalledTimes(0);
+    await log.flush();
+  
+    expect(fetch).toHaveBeenCalledTimes(3);
+  
+    const payload = (fetch as jest.Mock).mock.calls[0][1].body;
+    const firstLog = JSON.parse(payload);
+    expect(Object.keys(firstLog.fields).length).toEqual(2);
+    expect(firstLog.fields.foo).toEqual('bar');
+    expect(firstLog.fields.bar).toEqual('foo');
+    // ensure there is nothing was left unflushed
+    await log.flush();
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });

--- a/__tests__/transports/log-drain-transport.spec.ts
+++ b/__tests__/transports/log-drain-transport.spec.ts
@@ -1,0 +1,11 @@
+import LogDrainTransport from "../../src/transports/log-drain.transport";
+
+const mockedLog = jest.spyOn(global.console, 'log').mockImplementation();
+
+test('LogDrainTransport should print JSON log to console immediately', () => {
+    const transport = new LogDrainTransport();
+    const event = { _time: Date.now().toString(), level: 'info', message: 'hello, world!', fields: {} }
+    transport.log(event);
+    expect(mockedLog).toHaveBeenCalledTimes(1);
+    expect(mockedLog).toHaveBeenCalledWith(JSON.stringify(event));
+});

--- a/__tests__/transports/log-drain-transport.spec.ts
+++ b/__tests__/transports/log-drain-transport.spec.ts
@@ -1,6 +1,14 @@
+process.env.ENABLE_AXIOM_LOG_DRAIN = 'true';
+process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT = 'https://example.com/api/test';
+
+import { Logger } from "../../src/logger";
 import LogDrainTransport from "../../src/transports/log-drain.transport";
 
 const mockedLog = jest.spyOn(global.console, 'log').mockImplementation();
+
+afterEach(() => {
+    mockedLog.mockClear();
+})
 
 test('LogDrainTransport should print JSON log to console immediately', () => {
     const transport = new LogDrainTransport();
@@ -9,3 +17,10 @@ test('LogDrainTransport should print JSON log to console immediately', () => {
     expect(mockedLog).toHaveBeenCalledTimes(1);
     expect(mockedLog).toHaveBeenCalledWith(JSON.stringify(event));
 });
+
+test('LogDrainTransport should be selected when flag is enabled', () => {
+    const logger = new Logger()
+    logger.info('test_log_drain')
+    expect(logger.transport instanceof LogDrainTransport).toBe(true);
+    expect(mockedLog).toHaveBeenCalledTimes(1);
+})

--- a/examples/logger/package-lock.json
+++ b/examples/logger/package-lock.json
@@ -21,7 +21,6 @@
             }
         },
         "../..": {
-            "name": "next-axiom",
             "version": "0.16.0",
             "license": "MIT",
             "dependencies": {

--- a/examples/logger/pages/hello.tsx
+++ b/examples/logger/pages/hello.tsx
@@ -1,0 +1,18 @@
+import { log } from 'next-axiom'
+import { GetStaticProps } from 'next'
+
+export const getStaticProps: GetStaticProps =  async (context) => {
+  log.info('Hello from SSR', { context })
+  return {
+    props: {},
+  }
+}
+
+export default function Home() {
+    log.info('frontend logger')
+  return (
+    <div>
+      <h1>Hello, World!</h1>
+    </div>
+  )
+}

--- a/examples/logger/pages/index.tsx
+++ b/examples/logger/pages/index.tsx
@@ -19,6 +19,7 @@ const fetcher = async (args: any[]) => {
 
 export default function Home() {
   const { data, error } = useSWR('/api/hello', fetcher)
+  console.log(error)
 
   if (error) return <div>Failed to load</div>
   if (!data) return <div>Loading...</div>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "tsc",
     "prepare": "npm run build",
     "format": "prettier --write src/*.ts __tests__/*.ts",
-    "check-format": "prettier -c src/*.ts __tests__/*.ts",
+    "lint": "prettier -c src/*.ts __tests__/*.ts",
     "test": "jest"
   },
   "repository": {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,6 +4,7 @@ import Transport from './transports/transport';
 import ConsoleTransport from './transports/console.transport';
 import LogDrainTransport from './transports/log-drain.transport';
 import FetchTransport from './transports/fetch.transport';
+import { enableLogDrain } from './shared';
 
 const LOG_LEVEL = process.env.AXIOM_LOG_LEVEL || 'debug';
 
@@ -61,7 +62,7 @@ export class Logger {
     // decide which transport to use, if log drain is set, use that, otherwise use fetch, or fallback to console
     if (!config.isEnvVarsSet()) {
       this.transport = new ConsoleTransport();
-    } else if (isVercel && !config.isBrowser) {
+    } else if (isVercel && !config.isBrowser && enableLogDrain) {
       // if running in a lambda or edge function and axiom log drain is enabled,
       // use the log drain transport
       this.transport = new LogDrainTransport();
@@ -121,10 +122,6 @@ export class Logger {
     }
 
     this.transport.log(logEvent);
-    // TODO: should we call flush here? should the child loggers flush as well?
-    // if (this.autoFlush) {
-    //   this.flush();
-    // }
   };
 
   attachResponseStatus = (statusCode: number) => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -49,7 +49,7 @@ export interface PlatformInfo {
 export class Logger {
   children: Logger[] = [];
   public logLevel: string;
-  private transport: Transport;
+  public transport: Transport;
 
   constructor(
     private args: { [key: string]: any } = {},

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -54,7 +54,6 @@ export class Logger {
   constructor(
     private args: { [key: string]: any } = {},
     private req: RequestReport | null = null,
-    private autoFlush: boolean = true,
     public source: 'frontend' | 'lambda' | 'edge' = 'frontend',
     logLevel?: string
   ) {
@@ -67,7 +66,7 @@ export class Logger {
       // use the log drain transport
       this.transport = new LogDrainTransport();
     } else {
-      this.transport = new FetchTransport(autoFlush);
+      this.transport = new FetchTransport();
     }
   }
 
@@ -85,13 +84,13 @@ export class Logger {
   };
 
   with = (args: { [key: string]: any }) => {
-    const child = new Logger({ ...this.args, ...args }, this.req, this.autoFlush, this.source);
+    const child = new Logger({ ...this.args, ...args }, this.req, this.source);
     this.children.push(child);
     return child;
   };
 
   withRequest = (req: RequestReport) => {
-    return new Logger({ ...this.args }, req, this.autoFlush, this.source);
+    return new Logger({ ...this.args }, req, this.source);
   };
 
   _log = (level: string, message: string, args: { [key: string]: any } = {}) => {
@@ -122,16 +121,6 @@ export class Logger {
     }
 
     this.transport.log(logEvent);
-  };
-
-  attachResponseStatus = (statusCode: number) => {
-    // TODO: find a better way to handle response status
-    // this.logEvents = this.logEvents.map((log) => {
-    //   if (log.request) {
-    //     log.request.statusCode = statusCode;
-    //   }
-    //   return log;
-    // });
   };
 
   async flush() {

--- a/src/platform/base.ts
+++ b/src/platform/base.ts
@@ -6,7 +6,6 @@ import { EndpointType } from '../shared';
 // configrations per provider, and the functions that are used by the logger. Implement
 // this interface to have special behaviour for your platform.
 export default interface Provider {
-  shoudSendEdgeReport: boolean;
   token: string | undefined;
   environment: string;
   region: string | undefined;
@@ -19,4 +18,6 @@ export default interface Provider {
   generateRequestMeta(req: any): RequestReport;
   getLogsEndpoint(): string
   getWebVitalsEndpoint(): string
+  shouldSendEdgeReport(): boolean
+  shouldSendLambdaReport(): boolean
 }

--- a/src/platform/generic.ts
+++ b/src/platform/generic.ts
@@ -66,4 +66,7 @@ export default class GenericConfig implements Provider {
   getHeaderOrDefault(req: NextApiRequest | GetServerSidePropsContext['req'], headerName: string, defaultValue: any) {
     return req.headers[headerName] ? req.headers[headerName] : defaultValue;
   }
+
+  shouldSendEdgeReport = () => true
+  shouldSendLambdaReport = () => true
 }

--- a/src/platform/vercel.ts
+++ b/src/platform/vercel.ts
@@ -7,7 +7,6 @@ const ingestEndpoint = process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT || process.
 
 export default class VercelConfig extends GenericConfig implements Provider {
   provider = 'vercel';
-  shoudSendEdgeReport = true;
   region = process.env.VERCEL_REGION || undefined;
   environment = process.env.VERCEL_ENV || process.env.NODE_ENV;
   token = undefined;
@@ -41,4 +40,8 @@ export default class VercelConfig extends GenericConfig implements Provider {
       source: source,
     };
   }
+
+  shouldSendEdgeReport = () => true
+  // lambda report is automatically sent by vercel
+  shouldSendLambdaReport = () => false
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,5 @@
 export const isNoPrettyPrint = process.env.AXIOM_NO_PRETTY_PRINT == 'true' ? true : false;
+export const enableLogDrain = process.env.ENABLE_AXIOM_LOG_DRAIN == 'true' ? true : false;
 
 export enum EndpointType {
   webVitals = 'web-vitals',

--- a/src/transports/console.transport.ts
+++ b/src/transports/console.transport.ts
@@ -1,0 +1,71 @@
+import Transport from './transport';
+import { LogEvent } from '../logger';
+import config from '../config';
+import { isNoPrettyPrint } from '../shared';
+
+const levelColors = {
+  info: {
+    terminal: '32',
+    browser: 'lightgreen',
+  },
+  debug: {
+    terminal: '36',
+    browser: 'lightblue',
+  },
+  warn: {
+    terminal: '33',
+    browser: 'yellow',
+  },
+  error: {
+    terminal: '31',
+    browser: 'red',
+  },
+};
+
+export default class ConsoleTransport implements Transport {
+  log(event: LogEvent): Promise<void> {
+    this.prettyPrint(event);
+    return Promise.resolve();
+  }
+
+  prettyPrint(ev: LogEvent) {
+    const hasFields = Object.keys(ev.fields).length > 0;
+    // check whether pretty print is disabled
+    if (isNoPrettyPrint) {
+      let msg = `${ev.level} - ${ev.message}`;
+      if (hasFields) {
+        msg += ' ' + JSON.stringify(ev.fields);
+      }
+      console.log(msg);
+      return;
+    }
+    // print indented message, instead of [object]
+    // We use the %o modifier instead of JSON.stringify because stringify will print the
+    // object as normal text, it loses all the functionality the browser gives for viewing
+    // objects in the console, such as expanding and collapsing the object.
+    let msgString = '';
+    let args: any[] = [ev.level, ev.message];
+
+    if (config.isBrowser) {
+      msgString = '%c%s - %s';
+      args = [`color: ${levelColors[ev.level].browser};`, ...args];
+    } else {
+      msgString = `\x1b[${levelColors[ev.level].terminal}m%s\x1b[0m - %s`;
+    }
+    // we check if the fields object is not empty, otherwise its printed as <empty string>
+    // or just "".
+    if (hasFields) {
+      msgString += ' %o';
+      args.push(ev.fields);
+    }
+
+    if (ev.request) {
+      msgString += ' %o';
+      args.push(ev.request);
+    }
+
+    console.log.apply(console, [msgString, ...args]);
+  }
+
+  flush = () => Promise.resolve();
+}

--- a/src/transports/fetch.transport.ts
+++ b/src/transports/fetch.transport.ts
@@ -8,13 +8,11 @@ export default class FetchTransport implements Transport {
   public logEvents: LogEvent[] = [];
   throttledSendLogs = throttle(this.sendLogs, 1000);
 
-  constructor(public autoFlush: boolean = true) {}
+  constructor() {}
 
   async log(event: LogEvent): Promise<void> {
     this.logEvents.push(event);
-    if (this.autoFlush) {
-      this.throttledSendLogs()
-    }
+    this.throttledSendLogs()
     return Promise.resolve();
   }
 

--- a/src/transports/fetch.transport.ts
+++ b/src/transports/fetch.transport.ts
@@ -1,0 +1,59 @@
+import config, { isVercel, Version } from '../config';
+import { LogEvent } from '../logger';
+import { throttle } from '../shared';
+import Transport from './transport';
+
+export default class FetchTransport implements Transport {
+  public url = config.getLogsEndpoint();
+  public logEvents: LogEvent[] = [];
+  throttledSendLogs = throttle(this.sendLogs, 1000);
+
+  constructor(public autoFlush: boolean = true) {}
+
+  async log(event: LogEvent): Promise<void> {
+    this.logEvents.push(event);
+    if (this.autoFlush) {
+        this.throttledSendLogs()
+    }
+    return Promise.resolve();
+  }
+
+  async sendLogs() {
+    const method = 'POST';
+    const keepalive = true;
+    const body = JSON.stringify(this.logEvents);
+    // clear pending logs
+    this.logEvents = [];
+    // fire request to ingest logs
+    const headers = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'next-axiom/v' + Version,
+    };
+    if (config.token) {
+      headers['Authorization'] = `Bearer ${config.token}`;
+    }
+    const reqOptions: RequestInit = { body, method, keepalive, headers };
+
+    // Do not leak network errors; does not affect the running app
+    const sendFallback = () => fetch(this.url, reqOptions).catch(console.error);
+
+    try {
+      if (typeof fetch === 'undefined') {
+        const fetch = await require('whatwg-fetch');
+        fetch(this.url, reqOptions).catch(console.error);
+      } else if (config.isBrowser && isVercel && navigator.sendBeacon) {
+        // sendBeacon fails if message size is greater than 64kb, so
+        // we fall back to fetch.
+        if (!navigator.sendBeacon(this.url, body)) {
+          await sendFallback();
+        }
+      } else {
+        await sendFallback();
+      }
+    } catch (e) {
+      console.error(`Failed to send logs to Axiom: ${e}`);
+    }
+  }
+
+  flush = () => this.sendLogs();
+}

--- a/src/transports/fetch.transport.ts
+++ b/src/transports/fetch.transport.ts
@@ -13,12 +13,16 @@ export default class FetchTransport implements Transport {
   async log(event: LogEvent): Promise<void> {
     this.logEvents.push(event);
     if (this.autoFlush) {
-        this.throttledSendLogs()
+      this.throttledSendLogs()
     }
     return Promise.resolve();
   }
 
   async sendLogs() {
+    if (!this.logEvents.length) {
+      return
+    }
+
     const method = 'POST';
     const keepalive = true;
     const body = JSON.stringify(this.logEvents);

--- a/src/transports/log-drain.transport.ts
+++ b/src/transports/log-drain.transport.ts
@@ -1,0 +1,11 @@
+import Transport from "./transport";
+import { LogEvent } from '../logger'
+
+export default class LogDrainTransport implements Transport {
+    log(event: LogEvent): Promise<void> {
+        console.log(JSON.stringify(event))
+        return Promise.resolve()
+    }
+
+    flush = () => Promise.resolve()
+}

--- a/src/transports/transport.ts
+++ b/src/transports/transport.ts
@@ -1,0 +1,6 @@
+import { LogEvent } from "../logger";
+
+export default interface Transport {
+    log(event: LogEvent): Promise<void>;
+    flush(): Promise<void>;
+}


### PR DESCRIPTION
Closes DX-467;

introduced transports, where the logger can decide which transport to use based on the environment variables.
a special transport for LogDrain support is included, to improve logging performance on lambda/edge functions running on Vercel platform where the integration is enabled. Users who would like to use this should export an environment variable to use that transport.

```
export ENABLE_AXIOM_LOG_DRAIN=true
```

## TODO:

- [ ] find a way to attach response status to console logs