### PR TITLE
Feat(#109): use googles web vitals

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more information, check out the [official documentation](https://axiom.co/do
 
 ### Using Vercel Integration
 
-Make sure you have the [Axiom Vercel integration](https://www.axiom.co/vercel) installed. Once it is done, perform the steps below: 
+Make sure you have the [Axiom Vercel integration](https://www.axiom.co/vercel) installed. Once it is done, perform the steps below:
 
 - In your Next.js project, run install `next-axiom` as follows:
 
@@ -65,14 +65,22 @@ module.exports = withAxiom({
 
 ### Web Vitals
 
-next-axiom utilizies google's web-vitals to report the metrics
-to axiom.
+next-axiom provides a component that you can append to your layout to report web vitals to Axiom.
 
-To set it up, updates `pages/_app.js` or `pages/_app.ts` and add the following line to report web vitals:
+To set it up, update `pages/_app.js` or `app/layout.tsx` and add `<AxiomReporter />` to report web vitals:
 
 ```js
-import { reportWebVitals } from 'next-axiom';
-reportWebVitals()
+import { AxiomReporter } from 'next-axiom';
+
+function RootLayout({ Component, pageProps }: AppProps) {
+
+  return (
+    <>
+      <Component {...pageProps} />
+      <AxiomReporter />
+    </>
+  );
+}
 ```
 
 > **Note**: WebVitals are only sent from production deployments.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ module.exports = withAxiom({
 
 ### Web Vitals
 
-:warning: Web-Vitals are not yet supported in Next.js 13 and above. Please use Next.js 12 or below.
+next-axiom utilizies google's web-vitals to report the metrics
+to axiom.
 
-Go to `pages/_app.js` or `pages/_app.ts` and add the following line to report web vitals:
+To set it up, updates `pages/_app.js` or `pages/_app.ts` and add the following line to report web vitals:
 
 ```js
-export { reportWebVitals } from 'next-axiom';
+import { reportWebVitals } from 'next-axiom';
+reportWebVitals()
 ```
 
 > **Note**: WebVitals are only sent from production deployments.

--- a/__tests__/noEnvVars.test.ts
+++ b/__tests__/noEnvVars.test.ts
@@ -8,9 +8,9 @@ process.env.AXIOM_DATASET = '';
 process.env.AXIOM_TOKEN = '';
 process.env.AXIOM_INGEST_ENDPOINT = '';
 process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT = '';
-import { NextWebVitalsMetric } from 'next/app';
+import { Metric } from 'web-vitals';
 import { log } from '../src/logger';
-import { reportWebVitals } from '../src/webVitals';
+import { reportWebVital, reportWebVitals } from '../src/webVitals';
 
 jest.useFakeTimers();
 global.fetch = jest.fn() as jest.Mock;
@@ -24,8 +24,17 @@ test('sending logs on localhost should fallback to console', () => {
 });
 
 test('webVitals should not be sent when envVars are not set', () => {
-  const metric: NextWebVitalsMetric = { id: '1', startTime: 1234, value: 1, name: 'FCP', label: 'web-vital' };
-  reportWebVitals(metric);
+  reportWebVitals();
+  const metric: Metric = {
+    id: '1',
+    value: 1,
+    name: 'FCP',
+    rating: 'good',
+    delta: 1,
+    entries: [],
+    navigationType: 'reload',
+  };
+  reportWebVital(metric);
   jest.advanceTimersByTime(1000);
   expect(fetch).toHaveBeenCalledTimes(0);
 });

--- a/__tests__/webvitals.test.ts
+++ b/__tests__/webvitals.test.ts
@@ -2,32 +2,32 @@
  * @jest-environment jsdom
  */
 import { jest } from '@jest/globals';
-import { NextWebVitalsMetric } from 'next/app';
 // set axiom env vars before importing webvitals
 process.env.AXIOM_URL = '';
 process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT = 'https://example.co/api/test';
-import { reportWebVitals } from '../src/webVitals';
+import { reportWebVital } from '../src/webVitals';
 import 'whatwg-fetch';
 import { Version } from '../src/config';
+import { Metric } from 'web-vitals';
 
 global.fetch = jest.fn(() => Promise.resolve(new Response('', { status: 204, statusText: 'OK' }))) as jest.Mock;
 jest.useFakeTimers();
 
 test('throttled sendMetrics', async () => {
-  let metricsMatrix: NextWebVitalsMetric[][] = [
+  let metricsMatrix: Metric[][] = [
     [
-      { id: '1', startTime: 1234, value: 1, name: 'FCP', label: 'web-vital' },
-      { id: '2', startTime: 5678, value: 2, name: 'FCP', label: 'web-vital' },
+      { id: '1', value: 2, name: 'FCP', rating: 'good', delta: 1, entries: [], navigationType: 'reload' },
+      { id: '2', value: 1, name: 'FCP', rating: 'poor', delta: 1, entries: [], navigationType: 'reload' },
     ],
-    [{ id: '3', startTime: 9012, value: 3, name: 'FCP', label: 'web-vital' }],
-    [{ id: '4', startTime: 4012, value: 4, name: 'FCP', label: 'web-vital' }],
+    [{ id: '3', value: 1, name: 'FCP', rating: 'poor', delta: 1, entries: [], navigationType: 'reload' }],
+    [{ id: '4', value: 1, name: 'FCP', rating: 'poor', delta: 1, entries: [], navigationType: 'reload' }],
   ];
 
   // report first set of web-vitals
-  metricsMatrix[0].forEach(reportWebVitals);
+  metricsMatrix[0].forEach(reportWebVital);
   // skip 100ms and report another webVital
   jest.advanceTimersByTime(100);
-  metricsMatrix[1].forEach(reportWebVitals);
+  metricsMatrix[1].forEach(reportWebVital);
   // ensure fetch has not been called yet for any the previously reported
   // web-vitals
   expect(fetch).toBeCalledTimes(0);
@@ -35,7 +35,7 @@ test('throttled sendMetrics', async () => {
   jest.advanceTimersByTime(1000);
 
   // send the last set of webVitals and wait for them to be sent
-  metricsMatrix[2].forEach(reportWebVitals);
+  metricsMatrix[2].forEach(reportWebVital);
   jest.advanceTimersByTime(1000);
 
   const url = '/_axiom/web-vitals';

--- a/examples/logger/package-lock.json
+++ b/examples/logger/package-lock.json
@@ -9,7 +9,7 @@
                 "next-axiom": "file:../../",
                 "react": "18.0.0",
                 "react-dom": "18.0.0",
-                "swr": "^1.3.0"
+                "swr": "^2.1.0"
             },
             "devDependencies": {
                 "@types/node": "18.11.9",
@@ -21,10 +21,11 @@
             }
         },
         "../..": {
-            "name": "next-axiom",
-            "version": "0.16.0",
+            "version": "0.17.0",
             "license": "MIT",
             "dependencies": {
+                "client-only": "^0.0.1",
+                "web-vitals": "^3.1.1",
                 "whatwg-fetch": "^3.6.2"
             },
             "devDependencies": {
@@ -2831,9 +2832,15 @@
             }
         },
         "node_modules/swr": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
-            "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.0.tgz",
+            "integrity": "sha512-4hYl5p3/KalQ1MORealM79g/DtLohmud6yyfXw5l4wjtFksYUnocRFudvyaoUtgj3FrVNK9lS25Av9dsZYvz0g==",
+            "dependencies": {
+                "use-sync-external-store": "^1.2.0"
+            },
+            "engines": {
+                "pnpm": "7"
+            },
             "peerDependencies": {
                 "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
             }
@@ -4565,12 +4572,14 @@
             "requires": {
                 "@types/jest": "^27.5.1",
                 "@types/node": "^17.0.29",
+                "client-only": "^0.0.1",
                 "jest": "^28.1.0",
                 "jest-environment-jsdom": "^28.1.0",
                 "prettier": "2.6.2",
                 "ts-jest": "^28.0.2",
                 "ts-node": "^10.8.0",
                 "typescript": "^4.6.4",
+                "web-vitals": "^3.1.1",
                 "whatwg-fetch": "^3.6.2"
             }
         },
@@ -4986,10 +4995,12 @@
             "dev": true
         },
         "swr": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
-            "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
-            "requires": {}
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.0.tgz",
+            "integrity": "sha512-4hYl5p3/KalQ1MORealM79g/DtLohmud6yyfXw5l4wjtFksYUnocRFudvyaoUtgj3FrVNK9lS25Av9dsZYvz0g==",
+            "requires": {
+                "use-sync-external-store": "^1.2.0"
+            }
         },
         "text-table": {
             "version": "0.2.0",

--- a/examples/logger/package.json
+++ b/examples/logger/package.json
@@ -11,15 +11,14 @@
         "next-axiom": "file:../../",
         "react": "18.0.0",
         "react-dom": "18.0.0",
-        "swr": "^1.3.0"
+        "swr": "^2.1.0"
     },
     "devDependencies": {
-        "eslint": "8.12.0",
-        "eslint-config-next": "12.1.4",
         "@types/node": "18.11.9",
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.9",
+        "eslint": "8.12.0",
+        "eslint-config-next": "12.1.4",
         "typescript": "4.9.3"
     }
 }
-

--- a/examples/logger/pages/_app.tsx
+++ b/examples/logger/pages/_app.tsx
@@ -1,12 +1,13 @@
 import { log, reportWebVitals } from 'next-axiom'
-import {AppProps} from "next/app";
+import { AppProps } from "next/app";
+import { useEffect } from 'react';
 
 log.info('Hello from frontend', { foo: 'bar' })
 
 function MyApp({ Component, pageProps }: AppProps) {
+  useEffect(() => reportWebVitals(), [])
+
   return <Component {...pageProps} />
 }
-
-reportWebVitals()
 
 export default MyApp

--- a/examples/logger/pages/_app.tsx
+++ b/examples/logger/pages/_app.tsx
@@ -1,12 +1,12 @@
-import { log } from 'next-axiom'
+import { log, reportWebVitals } from 'next-axiom'
 import {AppProps} from "next/app";
-
-export { reportWebVitals } from 'next-axiom'
 
 log.info('Hello from frontend', { foo: 'bar' })
 
 function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />
 }
+
+reportWebVitals()
 
 export default MyApp

--- a/examples/logger/pages/index.tsx
+++ b/examples/logger/pages/index.tsx
@@ -1,26 +1,29 @@
 import { log } from 'next-axiom'
 import { GetStaticProps } from 'next'
-import useSWR, { BareFetcher } from 'swr'
+import useSWR from 'swr'
 
-export const getStaticProps: GetStaticProps =  async (context) => {
+export const getStaticProps: GetStaticProps = async (context) => {
   log.info('Hello from SSR', { context })
   return {
     props: {},
   }
 }
 
-const fetcher = async (args: any[]) => {
-  console.log('Fetching', args)
-  log.info('Hello from SWR', { args });
+const fetcher = async (url: string) => {
+  console.log('Fetching', url)
+  log.info('Hello from SWR', { url });
   // @ts-ignore
-  const res = await fetch(...args);
+  const res = await fetch(url);
   return await res.json();
 }
 
 export default function Home() {
   const { data, error } = useSWR('/api/hello', fetcher)
 
-  if (error) return <div>Failed to load</div>
+  if (error) {
+    console.log(error)
+    return <div>Failed to load</div>
+  }
   if (!data) return <div>Loading...</div>
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
+        "web-vitals": "^3.1.1",
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
@@ -4540,6 +4541,11 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.1.1.tgz",
+      "integrity": "sha512-qvllU+ZeQChqzBhZ1oyXmWsjJ8a2jHYpH8AMaVuf29yscOPZfTQTjQFRX6+eADTdsDE8IanOZ0cetweHMs8/2A=="
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -8086,6 +8092,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-vitals": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.1.1.tgz",
+      "integrity": "sha512-qvllU+ZeQChqzBhZ1oyXmWsjJ8a2jHYpH8AMaVuf29yscOPZfTQTjQFRX6+eADTdsDE8IanOZ0cetweHMs8/2A=="
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "web-vitals": "^3.1.1",
+        "client-only": "^0.0.1",
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
@@ -26,7 +26,8 @@
         "node": ">=15"
       },
       "peerDependencies": {
-        "next": "^12.1.4 || ^13"
+        "next": "^12.1.4 || ^13",
+        "web-vitals": "^3.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1816,6 +1817,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -4542,9 +4548,10 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.1.1.tgz",
-      "integrity": "sha512-qvllU+ZeQChqzBhZ1oyXmWsjJ8a2jHYpH8AMaVuf29yscOPZfTQTjQFRX6+eADTdsDE8IanOZ0cetweHMs8/2A=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.3.0.tgz",
+      "integrity": "sha512-GZsEmJBNclIpViS/7QVOTr7Kbt4BgLeR7kQ5zCCtJVuiWsA+K6xTXaoEXssvl8yYFICEyNmA2Nr+vgBYTnS4bA==",
+      "peer": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -6089,6 +6096,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -8094,9 +8106,10 @@
       }
     },
     "web-vitals": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.1.1.tgz",
-      "integrity": "sha512-qvllU+ZeQChqzBhZ1oyXmWsjJ8a2jHYpH8AMaVuf29yscOPZfTQTjQFRX6+eADTdsDE8IanOZ0cetweHMs8/2A=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.3.0.tgz",
+      "integrity": "sha512-GZsEmJBNclIpViS/7QVOTr7Kbt4BgLeR7kQ5zCCtJVuiWsA+K6xTXaoEXssvl8yYFICEyNmA2Nr+vgBYTnS4bA==",
+      "peer": true
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "web-vitals": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
+    "web-vitals": "^3.1.1",
     "whatwg-fetch": "^3.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "homepage": "https://github.com/axiomhq/next-axiom#readme",
   "peerDependencies": {
-    "next": "^12.1.4 || ^13"
+    "next": "^12.1.4 || ^13",
+    "web-vitals": "^3.1.1"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",
@@ -49,7 +50,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "web-vitals": "^3.1.1",
+    "client-only": "^0.0.1",
     "whatwg-fetch": "^3.6.2"
   }
 }

--- a/src/components/reporter.tsx
+++ b/src/components/reporter.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { useReportWebVitals } from 'next/client';
+import { reportWebVital } from '../webVitals';
+
+export function AxiomReporter() {
+  useReportWebVitals(reportWebVital);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export { reportWebVitals, reportWebVital } from './webVitals';
+export { reportWebVital } from './webVitals';
 export { log, Logger } from './logger';
+export { AxiomReporter } from './components/reporter';
 export {
   withAxiom,
   withAxiomGetServerSideProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { reportWebVitals } from './webVitals';
+export { reportWebVitals, reportWebVital } from './webVitals';
 export { log, Logger } from './logger';
 export { withAxiom, AxiomAPIRequest, AxiomRequest } from './withAxiom';

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -1,6 +1,7 @@
+import 'client-only';
 import { throttle } from './shared';
-import config, { isVercel, Version } from './config';
-import { onLCP, onFID, onCLS, onINP, onFCP, onTTFB, Metric } from 'web-vitals';
+import config, { isVercel } from './config';
+import { Metric } from 'web-vitals';
 
 const url = config.getWebVitalsEndpoint();
 
@@ -19,24 +20,10 @@ export function reportWebVital(metric: Metric) {
   throttledSendMetrics();
 }
 
-export function reportWebVitals() {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  onCLS(reportWebVital);
-  onFID(reportWebVital);
-  onLCP(reportWebVital);
-  onINP(reportWebVital);
-  onFCP(reportWebVital);
-  onTTFB(reportWebVital);
-}
-
 function sendMetrics() {
   const body = JSON.stringify(config.wrapWebVitalsObject(collectedMetrics));
   const headers = {
     'Content-Type': 'application/json',
-    'User-Agent': 'next-axiom/v' + Version,
   };
   if (config.token) {
     headers['Authorization'] = `Bearer ${config.token}`;

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -9,7 +9,7 @@ export declare type WebVitalsMetric = Metric | { route: string };
 const throttledSendMetrics = throttle(sendMetrics, 1000);
 let collectedMetrics: WebVitalsMetric[] = [];
 
-function reportWebVital(metric: Metric) {
+export function reportWebVital(metric: Metric) {
   collectedMetrics.push({ route: window.__NEXT_DATA__?.page, ...metric });
   // if Axiom env vars are not set, do nothing,
   // otherwise devs will get errors on dev environments

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -1,15 +1,15 @@
-import { NextWebVitalsMetric } from 'next/app';
 import { throttle } from './shared';
 import config, { isVercel, Version } from './config';
+import {onLCP, onFID, onCLS, onINP, onFCP, onTTFB, Metric } from 'web-vitals';
 
 const url = config.getWebVitalsEndpoint();
 
-export declare type WebVitalsMetric = NextWebVitalsMetric & { route: string };
+export declare type WebVitalsMetric = Metric |  & { route: string };
 
 const throttledSendMetrics = throttle(sendMetrics, 1000);
 let collectedMetrics: WebVitalsMetric[] = [];
 
-export function reportWebVitals(metric: NextWebVitalsMetric) {
+function reportWebVital(metric: Metric ) {
   collectedMetrics.push({ route: window.__NEXT_DATA__?.page, ...metric });
   // if Axiom env vars are not set, do nothing,
   // otherwise devs will get errors on dev environments
@@ -17,6 +17,19 @@ export function reportWebVitals(metric: NextWebVitalsMetric) {
     return;
   }
   throttledSendMetrics();
+}
+
+export function reportWebVitals() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  onCLS(reportWebVital)
+  onFID(reportWebVital)
+  onLCP(reportWebVital)
+  onINP(reportWebVital)
+  onFCP(reportWebVital)
+  onTTFB(reportWebVital)
 }
 
 function sendMetrics() {

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -1,15 +1,15 @@
 import { throttle } from './shared';
 import config, { isVercel, Version } from './config';
-import {onLCP, onFID, onCLS, onINP, onFCP, onTTFB, Metric } from 'web-vitals';
+import { onLCP, onFID, onCLS, onINP, onFCP, onTTFB, Metric } from 'web-vitals';
 
 const url = config.getWebVitalsEndpoint();
 
-export declare type WebVitalsMetric = Metric |  & { route: string };
+export declare type WebVitalsMetric = Metric | { route: string };
 
 const throttledSendMetrics = throttle(sendMetrics, 1000);
 let collectedMetrics: WebVitalsMetric[] = [];
 
-function reportWebVital(metric: Metric ) {
+function reportWebVital(metric: Metric) {
   collectedMetrics.push({ route: window.__NEXT_DATA__?.page, ...metric });
   // if Axiom env vars are not set, do nothing,
   // otherwise devs will get errors on dev environments
@@ -21,15 +21,15 @@ function reportWebVital(metric: Metric ) {
 
 export function reportWebVitals() {
   if (typeof window === 'undefined') {
-    return
+    return;
   }
 
-  onCLS(reportWebVital)
-  onFID(reportWebVital)
-  onLCP(reportWebVital)
-  onINP(reportWebVital)
-  onFCP(reportWebVital)
-  onTTFB(reportWebVital)
+  onCLS(reportWebVital);
+  onFID(reportWebVital);
+  onLCP(reportWebVital);
+  onINP(reportWebVital);
+  onFCP(reportWebVital);
+  onTTFB(reportWebVital);
 }
 
 function sendMetrics() {


### PR DESCRIPTION
Nextjs 13 doesn't support reportWebVitals anymore, this PR replaces that with google's web-vitals package. 

# Breaking Change
Users doesn't have to export `reportWebVitals` any more, instead they would have to call it.

# example on results

This is how the current payload looks like

```json
{
    "webVitals": [
        {
            "route": "/",
            "name": "FCP",
            "value": 216,
            "rating": "good",
            "delta": 216,
            "entries": [
                {
                    "name": "first-contentful-paint",
                    "entryType": "paint",
                    "startTime": 216,
                    "duration": 0
                }
            ],
            "id": "v3-1675865668568-1652281525583",
            "navigationType": "reload"
        },
        {
            "route": "/",
            "name": "FCP",
            "value": 216,
            "rating": "good",
            "delta": 216,
            "entries": [
                {
                    "name": "first-contentful-paint",
                    "entryType": "paint",
                    "startTime": 216,
                    "duration": 0
                }
            ],
            "id": "v3-1675865668569-6068736136887",
            "navigationType": "reload"
        },
        {
            "route": "/",
            "name": "TTFB",
            "value": 130,
            "rating": "good",
            "delta": 130,
            "entries": [
                {
                    "name": "https://next-axiom-integration-test.vercel.app/",
                    "entryType": "navigation",
                    "startTime": 0,
                    "duration": 269,
                    "initiatorType": "navigation",
                    "nextHopProtocol": "h2",
                    "renderBlockingStatus": "blocking",
                    "workerStart": 0,
                    "redirectStart": 0,
                    "redirectEnd": 0,
                    "fetchStart": 4,
                    "domainLookupStart": 4,
                    "domainLookupEnd": 4,
                    "connectStart": 4,
                    "connectEnd": 4,
                    "secureConnectionStart": 4,
                    "requestStart": 9,
                    "responseStart": 130,
                    "responseEnd": 132,
                    "transferSize": 300,
                    "encodedBodySize": 1292,
                    "decodedBodySize": 3106,
                    "responseStatus": 0,
                    "serverTiming": [],
                    "unloadEventStart": 136,
                    "unloadEventEnd": 136,
                    "domInteractive": 198,
                    "domContentLoadedEventStart": 213,
                    "domContentLoadedEventEnd": 213,
                    "domComplete": 269,
                    "loadEventStart": 269,
                    "loadEventEnd": 269,
                    "type": "reload",
                    "redirectCount": 0
                }
            ],
            "id": "v3-1675865668568-9227052319451",
            "navigationType": "reload"
        },
        {
            "route": "/",
            "name": "TTFB",
            "value": 130,
            "rating": "good",
            "delta": 130,
            "entries": [
                {
                    "name": "https://next-axiom-integration-test.vercel.app/",
                    "entryType": "navigation",
                    "startTime": 0,
                    "duration": 269,
                    "initiatorType": "navigation",
                    "nextHopProtocol": "h2",
                    "renderBlockingStatus": "blocking",
                    "workerStart": 0,
                    "redirectStart": 0,
                    "redirectEnd": 0,
                    "fetchStart": 4,
                    "domainLookupStart": 4,
                    "domainLookupEnd": 4,
                    "connectStart": 4,
                    "connectEnd": 4,
                    "secureConnectionStart": 4,
                    "requestStart": 9,
                    "responseStart": 130,
                    "responseEnd": 132,
                    "transferSize": 300,
                    "encodedBodySize": 1292,
                    "decodedBodySize": 3106,
                    "responseStatus": 0,
                    "serverTiming": [],
                    "unloadEventStart": 136,
                    "unloadEventEnd": 136,
                    "domInteractive": 198,
                    "domContentLoadedEventStart": 213,
                    "domContentLoadedEventEnd": 213,
                    "domComplete": 269,
                    "loadEventStart": 269,
                    "loadEventEnd": 269,
                    "type": "reload",
                    "redirectCount": 0
                }
            ],
            "id": "v3-1675865668569-8381215440647",
            "navigationType": "reload"
        },
        {
            "route": "/",
            "name": "FCP",
            "value": 216,
            "rating": "good",
            "delta": 216,
            "entries": [
                {
                    "name": "first-contentful-paint",
                    "entryType": "paint",
                    "startTime": 216,
                    "duration": 0
                }
            ],
            "id": "v3-1675865668604-9910017087956",
            "navigationType": "reload"
        }
    ]
}
```

# Notes on payload

The payload is missing label and startTime, but I believe this is fine because they are not used in the dashboards. But what worries me is the duplication of metrics (multiple FCP and multiple TTFB) I am not sure if this is normal or or some thing is wrong.

# Questions

Should we get rid of entries or is it okay to keep them in the payload? They seem to be huge for TTFB.