### PR TITLE
Allow route override in reportWebVitals, bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "0.16.0",
+  "version": "0.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "0.16.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { reportWebVitals } from './webVitals';
+export { reportWebVitals, reportWebVitalsWithPath } from './webVitals';
 export { log, Logger } from './logger';
 export {
   withAxiom,

--- a/src/webVitals.ts
+++ b/src/webVitals.ts
@@ -10,7 +10,12 @@ const throttledSendMetrics = throttle(sendMetrics, 1000);
 let collectedMetrics: WebVitalsMetric[] = [];
 
 export function reportWebVitals(metric: NextWebVitalsMetric) {
-  collectedMetrics.push({ route: window.__NEXT_DATA__?.page, ...metric });
+  reportWebVitalsWithPath(metric);
+}
+
+export function reportWebVitalsWithPath(metric: NextWebVitalsMetric, path?: string) {
+  const route = path || window.__NEXT_DATA__?.page;
+  collectedMetrics.push({ route, ...metric });
   // if Axiom env vars are not set, do nothing,
   // otherwise devs will get errors on dev environments
   if (!config.isEnvVarsSet()) {


### PR DESCRIPTION
This adds an optional `path` parameter to a new `reportWebVitalsWithPath` function allowing people to specify their own value (e.g. falling back to `window.location.pathname`.

Here's an example for people that want the actual path (not the next path):
```typescript
import { NextWebVitalsMetric } from 'next/app'
import { reportWebVitalsWithPath } from 'next-axiom'

export function reportWebVitals(metric: NextWebVitalsMetric) {
  reportWebVitalsWithPath(metric, window.location.pathname)
}
```

This also bumps the version to 0.18.