### PR TITLE
fix(withAxiom): Change order, add return type

### DIFF
--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -58,7 +58,7 @@ type NextHandler<T = any> = (
   arg?: T
 ) => Promise<Response> | Promise<NextResponse> | NextResponse | Response;
 
-export function withAxiomRouteHandler(handler: NextHandler) {
+export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
   return async (req: Request | NextRequest, arg: any) => {
     let region = '';
     if ('geo' in req) {
@@ -113,8 +113,8 @@ function isNextConfig(param: WithAxiomParam): param is NextConfig {
 
 // withAxiom can be called either with NextConfig, which will add proxy rewrites
 // to improve deliverability of Web-Vitals and logs.
-export function withAxiom(param: NextConfig): NextConfig;
 export function withAxiom(param: NextHandler): NextHandler;
+export function withAxiom(param: NextConfig): NextConfig;
 export function withAxiom(param: WithAxiomParam) {
   if (typeof param == 'function') {
     return withAxiomRouteHandler(param);


### PR DESCRIPTION
The dynamic route in the example was failing when `withAxiom(param: NextConfig)` came before `withAxiom(NextHandler)`, reversing them did the trick.

See https://github.com/axiomhq/next-axiom/blob/9ec2a795b5d5e84b683c117e3a5058fb72573676/examples/logger/app/api/dynamic/%5Bid%5D/route.ts#L5