### PR TITLE
Fix wrong inference of return value of `withAxiomRouteHandler`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "prettier.semi": true,
+  "javascript.format.semicolons": "insert",
+  "typescript.format.semicolons": "insert"
+}

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Wrapping your Route Handlers in `withAxiom` will add a logger to your
 request and automatically log exceptions:
 
 ```typescript
-import { withAxiom, AxiomRequest } from 'next-axiom';
+import { withAxiom } from 'next-axiom';
 
-export const GET = withAxiom((req: AxiomRequest) => {
+export const GET = withAxiom((req) => {
   req.log.info('Login function called');
 
   // You can create intermediate loggers

--- a/examples/logger/app/api/dynamic/[id]/route.ts
+++ b/examples/logger/app/api/dynamic/[id]/route.ts
@@ -1,8 +1,8 @@
-import { AxiomRequest, withAxiom } from 'next-axiom';
+import { withAxiom } from 'next-axiom';
 
 export const runtime = 'edge';
 
-export const POST = withAxiom((req: AxiomRequest, { params }: { params: { id: string}}) => {
+export const POST = withAxiom((req, { params }: { params: { id: string}}) => {
     req.log.info('axiom dynamic route');
     return new Response(`Hello, Next.js! ${params.id}`);
 })

--- a/examples/logger/app/api/edge/route.ts
+++ b/examples/logger/app/api/edge/route.ts
@@ -1,8 +1,8 @@
-import { AxiomRequest, withAxiom } from 'next-axiom';
+import { withAxiom } from 'next-axiom';
 
 export const runtime = 'edge';
 
-export const GET = withAxiom(async (req: AxiomRequest) => {
+export const GET = withAxiom(async (req) => {
   req.log.info('fired from edge route');
   return new Response('Hello, Next.js!');
 });

--- a/examples/logger/app/api/lambda/route.ts
+++ b/examples/logger/app/api/lambda/route.ts
@@ -1,8 +1,8 @@
-import { AxiomRequest, withAxiom } from 'next-axiom';
+import { withAxiom } from 'next-axiom';
 
 export const runtime = 'edge';
 
-export const GET = withAxiom(async (req: AxiomRequest) => {
+export const GET = withAxiom(async (req) => {
   req.log.info('axiom lambda route');
   return new Response('Hello, Next.js!');
 });


### PR DESCRIPTION
`withAxiomRouteHandler` used to return always `NextResponse<unknown>`, it was giving me errors in my project.
I also added generics to the other `withAxios` function, that had the same problem.
And finally, now that the type inference is improved, there's no need to explicitly say that `req` is `AxiomRequest`, so I updated the example's code.

> [!WARNING]
> Be aware that I used a type cast that could be unsafe (`as T` in line 99), because I couldn't manage to do it in any other way. Maybe someone more experienced in TypeScript can find a better solution, but for now, mine is "good enough".