### PR TITLE
Dedupe logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "remeda": "^1.29.0",
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
@@ -3915,6 +3916,11 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/remeda": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.29.0.tgz",
+      "integrity": "sha512-M3LQ14KtMdQ1879lj/kKji3zBk158s7Rwg963mEkTfQFMxnKrIEAMxJfo/+0sp/+uGgN/KMVU2MBA4LNjqf8YQ=="
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7628,6 +7634,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "remeda": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.29.0.tgz",
+      "integrity": "sha512-M3LQ14KtMdQ1879lj/kKji3zBk158s7Rwg963mEkTfQFMxnKrIEAMxJfo/+0sp/+uGgN/KMVU2MBA4LNjqf8YQ=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "remeda": "^1.29.0",
     "whatwg-fetch": "^3.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,9 +1,21 @@
 import { usePathname } from 'next/navigation';
 import { Logger, LoggerConfig } from './logger';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useDeepMemo } from './util';
 
 export function useLogger(config: LoggerConfig = {}): Logger {
   const path = usePathname();
+
+  const memoizedConfig = useDeepMemo({
+    ...config,
+    args: {
+      ...(config.args ?? {}),
+      path,
+    },
+  });
+
+  const logger = useMemo(() => new Logger(memoizedConfig), [memoizedConfig]);
+
   useEffect(() => {
     return () => {
       if (logger) {
@@ -12,11 +24,5 @@ export function useLogger(config: LoggerConfig = {}): Logger {
     };
   }, [path]);
 
-  if (!config.args) {
-    config.args = {};
-  }
-  config.args.path = path;
-
-  const logger = new Logger(config);
   return logger;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,12 @@
+import { useRef } from 'react';
+import { equals } from 'remeda';
+
+export function useDeepMemo<T extends Record<string, unknown>>(value: T) {
+  const ref = useRef<T>();
+
+  if (!equals(value, ref.current)) {
+    ref.current = value;
+  }
+
+  return ref.current;
+}


### PR DESCRIPTION
- prevents logger being recreated on rerender by "deep memoizing" it based on config (ie comparing previous and new config by value, not reference) 
- installs Remeda for the `equals` function - mostly chose this lib because it's known to treeshake well. could also use lodash or write our own deepEquals to avoid the dependency.