### PR TITLE
utilize log drain on vercel functions

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -160,7 +160,7 @@ export class Logger {
     // to send logs to Axiom without HTTP.
     // This saves resources and time on lambda and edge functions
     if (isVercel && (this.config.source === 'edge' || this.config.source === 'lambda')) {
-      this.logEvents.forEach((ev) => console.log(ev));
+      this.logEvents.forEach((ev) => console.log(JSON.stringify(ev)));
       this.logEvents = [];
       return;
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -156,6 +156,15 @@ export class Logger {
       return;
     }
 
+    // if vercel integration is enabled, we can utilize the log drain
+    // to send logs to Axiom without HTTP.
+    // This saves resources and time on lambda and edge functions
+    if (isVercel && (this.config.source === 'edge' || this.config.source === 'lambda')) {
+      this.logEvents.forEach((ev) => console.log(ev));
+      this.logEvents = [];
+      return;
+    }
+
     const method = 'POST';
     const keepalive = true;
     const body = JSON.stringify(this.logEvents);

--- a/tests/vercelConfig.test.ts
+++ b/tests/vercelConfig.test.ts
@@ -29,15 +29,10 @@ test('logging to console when running on lambda', async () => {
 
   await logger.flush();
   expect(mockedConsole).toHaveBeenCalledTimes(1);
-  expect(mockedConsole).toHaveBeenCalledWith({
-    _time: time,
-    fields: {},
-    level: 'info',
-    message: 'hello, world!',
-    vercel: {
-      environment: 'test',
-      region: undefined,
-      source: 'lambda',
-    },
-  });
+
+  const calledWithPayload = JSON.parse(mockedConsole.mock.calls[0][0]);
+  expect(calledWithPayload.message).toEqual('hello, world!');
+  expect(calledWithPayload.level).toEqual('info');
+  expect(calledWithPayload._time).toEqual(time);
+  expect(calledWithPayload.vercel.source).toEqual('lambda');
 });

--- a/tests/vercelConfig.test.ts
+++ b/tests/vercelConfig.test.ts
@@ -1,6 +1,7 @@
 import { test, expect, vi } from 'vitest';
 import { config } from '../src/config';
 import { EndpointType } from '../src/shared';
+import { Logger } from '../src/logger';
 
 vi.hoisted(() => {
   process.env.NEXT_PUBLIC_AXIOM_URL = undefined;
@@ -13,4 +14,30 @@ test('reading vercel ingest endpoint', () => {
 
   url = config.getIngestURL(EndpointType.logs);
   expect(url).toEqual('https://api.axiom.co/v1/integrations/vercel?type=logs');
+});
+
+test('logging to console when running on lambda', async () => {
+  vi.useFakeTimers();
+  const mockedConsole = vi.spyOn(console, 'log');
+  const time = new Date(Date.now()).toISOString();
+
+  const logger = new Logger({
+    source: 'lambda',
+  });
+
+  logger.info('hello, world!');
+
+  await logger.flush();
+  expect(mockedConsole).toHaveBeenCalledTimes(1);
+  expect(mockedConsole).toHaveBeenCalledWith({
+    _time: time,
+    fields: {},
+    level: 'info',
+    message: 'hello, world!',
+    vercel: {
+      environment: 'test',
+      region: undefined,
+      source: 'lambda',
+    },
+  });
 });


### PR DESCRIPTION
Now that our vercel integration parses JSON we can utilize the log drain to send structured data. This will allow our users to send logs without having to do `console.log(stringify({message: '...'})`.

next-axiom will keep populating the events and attaching context/request meta as always.

some improvements we could do:

- log to console right away without the need to flush
- figure out a way to avoid causing field limits error.


note: this could be improved later on using the [transports](https://github.com/axiomhq/next-axiom/issues/142) logic mentioned in the linked issue. 