### PR TITLE
feat(logger): add `prettyPrint` in config

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -50,6 +50,7 @@ export type LoggerConfig = {
   autoFlush?: boolean;
   source?: string;
   req?: any;
+  prettyPrint?: typeof prettyPrint;
 };
 
 export class Logger {
@@ -60,6 +61,7 @@ export class Logger {
   public config: LoggerConfig = {
     autoFlush: true,
     source: 'frontend',
+    prettyPrint: prettyPrint,
   };
 
   constructor(public initConfig: LoggerConfig = {}) {
@@ -151,7 +153,7 @@ export class Logger {
     if (!config.isEnvVarsSet()) {
       // if AXIOM ingesting url is not set, fallback to printing to console
       // to avoid network errors in development environments
-      this.logEvents.forEach((ev) => prettyPrint(ev));
+      this.logEvents.forEach((ev) => (this.config.prettyPrint ? this.config.prettyPrint(ev) : prettyPrint(ev)));
       this.logEvents = [];
       return;
     }


### PR DESCRIPTION
Today, there is no way of customizing the way events are displayed when working locally (in development), they're systematically printed through the `prettyPrint()` function. It'd be nice to have a way to customize this behavior, for example by providing a custom function that would be called instead of `prettyPrint()`.

This PR adds a `prettyPrint` function in the `config` object passed in the `Logger` constructor. If provided, this function will be called instead of the default `prettyPrint()` function.

Exemple:

```typescript
const logger = new Logger({
  prettyPrint: (event) => {
    console.log(event.message);
  },
});
```
