### PR TITLE
prepare v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "remeda": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
This PR bumps the version in package.json to `1.2.0`, in order to the release the feature of printing to console when vercel integration is enabled.