### PR TITLE
Improve traffic and error capturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.next()
 
 
-// See "Matching Paths" below to learn more
 export const config = {
 }
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ const logger = new Logger({
 
 To capture routing errors we can use the [Error Handling](https://nextjs.org/docs/app/building-your-application/routing/error-handling) mechanism of Next. 
 
-Create a new file named `error.tsx` under your `/app` directory. Inside your component function use the logger to ingest the error to Axiom. e.g:
+Create a new file named `error.tsx` under your `/app` directory. Inside your component function use the logger to ingest the error to Axiom. 
+
+Example:
 
 ```typescript
 "use client";

--- a/README.md
+++ b/README.md
@@ -222,12 +222,8 @@ export default function ErrorPage({
   );
 
   return (
-    <div className="p-8">
+    <div>
       Ops! An Error has occurred:{" "}
-      <p className="text-red-400 px-8 py-2 text-lg">`{error.message}`</p>
-      <div className="w-1/3 mt-8">
-        <NavTable />
-      </div>
     </div>
   );
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Otherwise create a dataset and an API token in [Axiom settings](https://app.axio
 
 ## Capture traffic requests
 
-Create a `middleware.ts` in the root dir of your app:
+Create or edit the `middleware.ts` in the root directory of your app:
 
 ```typescript
 import { Logger } from 'next-axiom'
@@ -58,11 +58,12 @@ import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 
 export async function middleware(request: NextRequest, event: NextFetchEvent) {
-    const logger = new Logger({ source: 'middleware' }); // traffic, request
+    const logger = new Logger({ source: 'middleware' });
     logger.middleware(request)
 
     event.waitUntil(logger.flush())
     return NextResponse.next()
+}
 
 
 export const config = {
@@ -183,7 +184,7 @@ const logger = new Logger({
 
 To capture routing errors we can use the [Error Handling](https://nextjs.org/docs/app/building-your-application/routing/error-handling) mechanism of Next. 
 
-Create a new file named `error.tsx` under your `/app` directory. Inside your component function use the logger to ingest the error to Axiom. 
+Create or edit the `error.tsx` file under your `/app` directory. Inside your component function use the logger to ingest the error to Axiom. 
 
 Example:
 

--- a/examples/logger/error.tsx
+++ b/examples/logger/error.tsx
@@ -1,24 +1,42 @@
-'use client';
+"use client";
 
-import { useLogger } from 'next-axiom';
+import NavTable from "@/components/NavTable";
+import { LogLevel } from "@/next-axiom/logger";
+import { useLogger } from "next-axiom";
+import { usePathname } from "next/navigation";
 
-export default function Error({
+export default function ErrorPage({
   error,
 }: {
   error: Error & { digest?: string };
 }) {
-  const log = useLogger();
-  log.error(error.message, {
-    error: error.name,
-    cause: error.cause,
-    stack: error.stack,
-    digest: error.digest,
-  });
+  const pathname = usePathname()
+  const log = useLogger({ source: "error.tsx" });
+  let status =  error.message == 'Invalid URL' ? 404 : 500;
+
+  log.logHttpRequest(
+    LogLevel.error,
+    error.message,
+    {
+      host: window.location.href,
+      path: pathname,
+      statusCode: status,
+    },
+    {
+      error: error.name,
+      cause: error.cause,
+      stack: error.stack,
+      digest: error.digest,
+    },
+  );
 
   return (
     <div className="p-8">
-      Ops! An Error has occurred:{' '}
+      Ops! An Error has occurred:{" "}
       <p className="text-red-400 px-8 py-2 text-lg">`{error.message}`</p>
+      <div className="w-1/3 mt-8">
+        <NavTable />
+      </div>
     </div>
   );
 }

--- a/examples/logger/error.tsx
+++ b/examples/logger/error.tsx
@@ -31,12 +31,8 @@ export default function ErrorPage({
   );
 
   return (
-    <div className="p-8">
+    <div>
       Ops! An Error has occurred:{" "}
-      <p className="text-red-400 px-8 py-2 text-lg">`{error.message}`</p>
-      <div className="w-1/3 mt-8">
-        <NavTable />
-      </div>
     </div>
   );
 }

--- a/examples/logger/error.tsx
+++ b/examples/logger/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useLogger } from 'next-axiom';
+
+export default function Error({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  const log = useLogger();
+  log.error(error.message, {
+    error: error.name,
+    cause: error.cause,
+    stack: error.stack,
+    digest: error.digest,
+  });
+
+  return (
+    <div className="p-8">
+      Ops! An Error has occurred:{' '}
+      <p className="text-red-400 px-8 py-2 text-lg">`{error.message}`</p>
+    </div>
+  );
+}

--- a/examples/logger/middleware.ts
+++ b/examples/logger/middleware.ts
@@ -2,24 +2,9 @@ import { Logger } from 'next-axiom'
 import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 
-const logger = new Logger({ source: 'traffic' });
-
 export async function middleware(request: NextRequest, event: NextFetchEvent) {
-    const req = {
-        ip: request.ip,
-        region: request.geo?.region,
-        method: request.method,
-        host: request.nextUrl.hostname,
-        path: request.nextUrl.pathname,
-        scheme: request.nextUrl.protocol.split(":")[0],
-        referer: request.headers.get('Referer'),
-        userAgent: request.headers.get('user-agent'),
-    }
-
-    const message = `[${request.method}] [middleware: "middleware"] ${request.nextUrl.pathname}`
-
-    logger.logHttpRequest(message, req, {})
-
+    const logger = new Logger({ source: 'middleware' }); // traffic, request
+    logger.middleware(request)
 
     event.waitUntil(logger.flush())
     return NextResponse.next()

--- a/examples/logger/middleware.ts
+++ b/examples/logger/middleware.ts
@@ -3,13 +3,12 @@ import { NextResponse } from 'next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 
 export async function middleware(request: NextRequest, event: NextFetchEvent) {
-    const logger = new Logger({ source: 'middleware' }); // traffic, request
+    const logger = new Logger({ source: 'middleware' });
     logger.middleware(request)
 
     event.waitUntil(logger.flush())
     return NextResponse.next()
 }
 
-// See "Matching Paths" below to learn more
 export const config = {
 }

--- a/examples/logger/middleware.ts
+++ b/examples/logger/middleware.ts
@@ -1,0 +1,30 @@
+import { Logger } from 'next-axiom'
+import { NextResponse } from 'next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
+
+const logger = new Logger({ source: 'traffic' });
+
+export async function middleware(request: NextRequest, event: NextFetchEvent) {
+    const req = {
+        ip: request.ip,
+        region: request.geo?.region,
+        method: request.method,
+        host: request.nextUrl.hostname,
+        path: request.nextUrl.pathname,
+        scheme: request.nextUrl.protocol.split(":")[0],
+        referer: request.headers.get('Referer'),
+        userAgent: request.headers.get('user-agent'),
+    }
+
+    const message = `[${request.method}] [middleware: "middleware"] ${request.nextUrl.pathname}`
+
+    logger.logHttpRequest(message, req, {})
+
+
+    event.waitUntil(logger.flush())
+    return NextResponse.next()
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,10 @@ declare global {
 }
 
 export const Version = require('../package.json').version;
-export const isVercel = process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT || process.env.AXIOM_INGEST_ENDPOINT;
+// detect if Vercel integration & logdrain is enabled
+export const isVercelIntegration = process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT || process.env.AXIOM_INGEST_ENDPOINT;
+// detect if app is running on the Vercel platform
+export const isVercel = process.env.NEXT_PUBLIC_VERCEL || process.env.VERCEL;
 export const isNetlify = process.env.NETLIFY == 'true';
 export const isWebWorker =
   typeof self !== 'undefined' &&
@@ -20,7 +23,7 @@ export const isEdgeRuntime = globalThis.EdgeRuntime ? true : false;
 // Detect the platform provider, and return the appropriate config
 // fallback to generic config if no provider is detected
 let config = new GenericConfig();
-if (isVercel) {
+if (isVercelIntegration) {
   config = new VercelConfig();
 } else if (isNetlify) {
   config = new NetlifyConfig();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,8 +3,6 @@ import { config, isBrowser, isVercelIntegration, Version } from './config';
 import { NetlifyInfo } from './platform/netlify';
 import { isNoPrettyPrint, throttle } from './shared';
 
-
-
 const url = config.getLogsEndpoint();
 
 const LOG_LEVEL = process.env.NEXT_PUBLIC_AXIOM_LOG_LEVEL || 'debug';
@@ -15,14 +13,14 @@ export interface LogEvent {
   fields: any;
   _time: string;
   request?: RequestReport;
-  git?: any,
+  git?: any;
   source: string;
   platform?: PlatformInfo;
   vercel?: PlatformInfo;
   netlify?: NetlifyInfo;
-  "@app": {
-    "next-axiom-version": string;
-  }
+  '@app': {
+    'next-axiom-version': string;
+  };
 }
 
 export enum LogLevel {
@@ -78,7 +76,6 @@ export class Logger {
     autoFlush: true,
     source: 'frontend-log',
     prettyPrint: prettyPrint,
-
   };
 
   constructor(public initConfig: LoggerConfig = {}) {
@@ -122,9 +119,9 @@ export class Logger {
       _time: new Date(Date.now()).toISOString(),
       source: this.config.source!,
       fields: this.config.args || {},
-      "@app": {
-        "next-axiom-version": Version,
-      }
+      '@app': {
+        'next-axiom-version': Version,
+      },
     };
 
     // check if passed args is an object, if its not an object, add it to fields.args
@@ -149,7 +146,7 @@ export class Logger {
     }
 
     return logEvent;
-  }
+  };
 
   logHttpRequest(level: LogLevel, message: string, request: any, args: any) {
     const logEvent = this._transformEvent(level, message, args);
@@ -167,21 +164,21 @@ export class Logger {
       method: request.method,
       host: request.nextUrl.hostname,
       path: request.nextUrl.pathname,
-      scheme: request.nextUrl.protocol.split(":")[0],
+      scheme: request.nextUrl.protocol.split(':')[0],
       referer: request.headers.get('Referer'),
       userAgent: request.headers.get('user-agent'),
-    }
+    };
 
-    const message = `[${request.method}] [middleware: "middleware"] ${request.nextUrl.pathname}`
+    const message = `[${request.method}] [middleware: "middleware"] ${request.nextUrl.pathname}`;
 
-    return this.logHttpRequest(LogLevel.info, message, req, {})
+    return this.logHttpRequest(LogLevel.info, message, req, {});
   }
 
   private _log = (level: LogLevel, message: string, args: { [key: string]: any } = {}) => {
     if (level < this.logLevel) {
       return;
     }
-    const logEvent = this._transformEvent(level, message, args)
+    const logEvent = this._transformEvent(level, message, args);
 
     this.logEvents.push(logEvent);
     if (this.config.autoFlush) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,6 +13,7 @@ export interface LogEvent {
   _time: string;
   request?: RequestReport;
   git?: any,
+  source: string;
   platform?: PlatformInfo;
   vercel?: PlatformInfo;
   netlify?: NetlifyInfo;
@@ -111,6 +112,7 @@ export class Logger {
       level: LogLevel[level].toString(),
       message,
       _time: new Date(Date.now()).toISOString(),
+      source: this.config.source!,
       fields: this.config.args || {},
       "@axiom": {
         "next-axiom": Version,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -32,6 +32,7 @@ export enum LogLevel {
 
 export interface RequestReport {
   startTime: number;
+  endTime: number;
   statusCode?: number;
   ip?: string | null;
   region?: string | null;

--- a/src/platform/base.ts
+++ b/src/platform/base.ts
@@ -1,5 +1,4 @@
 import { NextWebVitalsMetric } from 'next/app';
-import { RequestReport } from '../logger';
 import { EndpointType } from '../shared';
 
 // This is the base class for all platform providers. It contains all the different
@@ -16,7 +15,6 @@ export default interface Provider {
   getIngestURL(t: EndpointType): string;
   wrapWebVitalsObject(metrics: NextWebVitalsMetric[]): any;
   injectPlatformMetadata(logEvent: any, source: string): void;
-  generateRequestMeta(req: any): RequestReport;
   getLogsEndpoint(): string
   getWebVitalsEndpoint(): string
 }

--- a/src/platform/generic.ts
+++ b/src/platform/generic.ts
@@ -1,5 +1,5 @@
 import { GetServerSidePropsContext, NextApiRequest } from "next";
-import { LogEvent, RequestReport } from "../logger";
+import { LogEvent } from "../logger";
 import { EndpointType } from "../shared";
 import type Provider from "./base";
 import { isBrowser, isVercel } from "../config";
@@ -20,7 +20,7 @@ export default class GenericConfig implements Provider {
   }
 
   getIngestURL(_: EndpointType): string {
-    return `${this.axiomUrl}/api/v1/datasets/${this.dataset}/ingest`;
+    return `${this.axiomUrl}/v1/datasets/${this.dataset}/ingest`;
   }
 
   getLogsEndpoint(): string {
@@ -67,19 +67,6 @@ export default class GenericConfig implements Provider {
         ref: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF,
       }
     }
-  }
-
-  generateRequestMeta(req: NextApiRequest | GetServerSidePropsContext['req']): RequestReport {
-    return {
-      startTime: new Date().getTime(),
-      path: req.url!,
-      method: req.method!,
-      host: this.getHeaderOrDefault(req, 'host', ''),
-      userAgent: this.getHeaderOrDefault(req, 'user-agent', ''),
-      scheme: 'https',
-      ip: this.getHeaderOrDefault(req, 'x-forwarded-for', ''),
-      region: this.region,
-    };
   }
 
   getHeaderOrDefault(req: NextApiRequest | GetServerSidePropsContext['req'], headerName: string, defaultValue: any) {

--- a/src/platform/generic.ts
+++ b/src/platform/generic.ts
@@ -39,6 +39,7 @@ export default class GenericConfig implements Provider {
         environment: this.environment,
         source: 'web-vital',
       },
+      source: 'web-vital'
     }))
   }
 
@@ -48,6 +49,7 @@ export default class GenericConfig implements Provider {
       key = "vercel"
     }
 
+    logEvent.source = source;
     logEvent[key] = {
       environment: this.environment,
       region: this.region,

--- a/src/platform/generic.ts
+++ b/src/platform/generic.ts
@@ -2,7 +2,7 @@ import { GetServerSidePropsContext, NextApiRequest } from "next";
 import { LogEvent, RequestReport } from "../logger";
 import { EndpointType } from "../shared";
 import type Provider from "./base";
-import { isBrowser } from "../config";
+import { isBrowser, isVercel } from "../config";
 
 // This is the generic config class for all platforms that doesn't have a special
 // implementation (e.g: vercel, netlify). All config classes extends this one.
@@ -33,21 +33,38 @@ export default class GenericConfig implements Provider {
 
   wrapWebVitalsObject(metrics: any[]): any {
     return metrics.map(m => ({
-        webVital: m,
-        _time: new Date().getTime(),
-        platform: {
-          environment: this.environment,
-          source: 'web-vital',
-        },
+      webVital: m,
+      _time: new Date().getTime(),
+      platform: {
+        environment: this.environment,
+        source: 'web-vital',
+      },
     }))
   }
 
   injectPlatformMetadata(logEvent: LogEvent, source: string) {
-    logEvent.platform = {
+    let key: "platform" | "vercel" | "netlify" = "platform"
+    if (isVercel) {
+      key = "vercel"
+    }
+
+    logEvent[key] = {
       environment: this.environment,
       region: this.region,
-      source: source + '-log',
+      source: source,
     };
+
+    if (isVercel) {
+      logEvent[key]!.region = process.env.VERCEL_REGION;
+      logEvent[key]!.deploymentId = process.env.VERCEL_DEPLOYMENT_ID;
+      logEvent[key]!.deploymentUrl = process.env.NEXT_PUBLIC_VERCEL_URL;
+      logEvent[key]!.project = process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL;
+      logEvent.git = {
+        commit: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+        repo: process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG,
+        ref: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF,
+      }
+    }
   }
 
   generateRequestMeta(req: NextApiRequest | GetServerSidePropsContext['req']): RequestReport {

--- a/src/platform/netlify.ts
+++ b/src/platform/netlify.ts
@@ -38,7 +38,7 @@ export default class NetlifyConfig extends GenericConfig implements Provider {
     logEvent.netlify = {
       environment: this.environment,
       region: source === 'edge' ? process.env.DENO_REGION : process.env.AWS_REGION,
-      source: source + '-log',
+      source: source,
       siteId: netlifySiteId,
       buildId: netlifyBuildId,
       context: netlifyContext,

--- a/src/webVitals/webVitals.ts
+++ b/src/webVitals/webVitals.ts
@@ -1,5 +1,5 @@
 import { NextWebVitalsMetric } from 'next/app';
-import { config, isBrowser, isVercel, Version } from '../config';
+import { config, isBrowser, isVercelIntegration, Version } from '../config';
 import { throttle } from '../shared';
 
 const url = config.getWebVitalsEndpoint();
@@ -35,7 +35,7 @@ function sendMetrics() {
     fetch(url, reqOptions).catch(console.error);
   }
 
-  if (isBrowser && isVercel && navigator.sendBeacon) {
+  if (isBrowser && isVercelIntegration && navigator.sendBeacon) {
     try {
       // See https://github.com/vercel/next.js/pull/26601
       // Navigator has to be bound to ensure it does not error in some browsers

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -1,7 +1,7 @@
 import { NextConfig } from 'next';
 import { Rewrite } from 'next/dist/lib/load-custom-routes';
 import { config, isEdgeRuntime, isVercelIntegration } from './config';
-import { Logger, RequestReport } from './logger';
+import { LogLevel, Logger, RequestReport } from './logger';
 import { NextRequest, type NextResponse } from 'next/server';
 import { EndpointType } from './shared';
 
@@ -97,7 +97,8 @@ export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
 
       // report log record
       report.statusCode = result.status;
-      logger.logHttpRequest(`[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`, report, {});
+      report.durationMs = report.endTime - report.startTime;
+      logger.logHttpRequest(LogLevel.info, `[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`, report, {});
       // attach the response status to all children logs
       log.attachResponseStatus(result.status)
 
@@ -111,7 +112,8 @@ export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
       report.endTime = new Date().getTime();
       // report log record
       report.statusCode = 500;
-      logger.logHttpRequest(`[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`, report, {});
+      report.durationMs = report.endTime - report.startTime;
+      logger.logHttpRequest(LogLevel.error, `[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`, report, {});
 
       log.error(error.message, { error })
       log.attachResponseStatus(500);

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -54,7 +54,6 @@ type NextHandler<T = any> = (
   arg?: T
 ) => Promise<Response> | Promise<NextResponse> | NextResponse | Response;
 
-
 export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
   return async (req: Request | NextRequest, arg: any) => {
     let region = '';
@@ -62,12 +61,12 @@ export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
       region = req.geo?.region ?? '';
     }
 
-    let pathname = ''
+    let pathname = '';
     if (req instanceof NextRequest) {
-      pathname = req.nextUrl.pathname
+      pathname = req.nextUrl.pathname;
     } else if (req instanceof Request) {
       // pathname = req.url.substring(req.headers.get('host')?.length || 0)
-      pathname = new URL(req.url).pathname
+      pathname = new URL(req.url).pathname;
     }
 
     const report: RequestReport = {
@@ -85,8 +84,8 @@ export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
     // main logger, mainly used to log reporting on the incoming HTTP request
     const logger = new Logger({ req: report, source: isEdgeRuntime ? 'edge' : 'lambda' });
     // child logger to be used by the users within the handler
-    const log = logger.with({})
-    log.config.source = isEdgeRuntime ? 'edge-log' : 'lambda-log'
+    const log = logger.with({});
+    log.config.source = isEdgeRuntime ? 'edge-log' : 'lambda-log';
     const axiomContext = req as AxiomRequest;
     const args = arg;
     axiomContext.log = log;
@@ -98,9 +97,14 @@ export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
       // report log record
       report.statusCode = result.status;
       report.durationMs = report.endTime - report.startTime;
-      logger.logHttpRequest(LogLevel.info, `[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`, report, {});
+      logger.logHttpRequest(
+        LogLevel.info,
+        `[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`,
+        report,
+        {}
+      );
       // attach the response status to all children logs
-      log.attachResponseStatus(result.status)
+      log.attachResponseStatus(result.status);
 
       // flush the logger along with the child logger
       await logger.flush();
@@ -113,9 +117,14 @@ export function withAxiomRouteHandler(handler: NextHandler): NextHandler {
       // report log record
       report.statusCode = 500;
       report.durationMs = report.endTime - report.startTime;
-      logger.logHttpRequest(LogLevel.error, `[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`, report, {});
+      logger.logHttpRequest(
+        LogLevel.error,
+        `[${req.method}] ${report.path} ${report.statusCode} ${report.endTime - report.startTime}ms`,
+        report,
+        {}
+      );
 
-      log.error(error.message, { error })
+      log.error(error.message, { error });
       log.attachResponseStatus(500);
 
       await logger.flush();

--- a/tests/vercelConfig.test.ts
+++ b/tests/vercelConfig.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, vi } from 'vitest';
-import { config } from '../src/config';
+import { config, isVercelIntegration } from '../src/config';
 import { EndpointType } from '../src/shared';
 import { Logger } from '../src/logger';
 
@@ -22,7 +22,7 @@ test('logging to console when running on lambda', async () => {
   const time = new Date(Date.now()).toISOString();
 
   const logger = new Logger({
-    source: 'lambda',
+    source: 'lambda-log',
   });
 
   logger.info('hello, world!');
@@ -34,5 +34,5 @@ test('logging to console when running on lambda', async () => {
   expect(calledWithPayload.message).toEqual('hello, world!');
   expect(calledWithPayload.level).toEqual('info');
   expect(calledWithPayload._time).toEqual(time);
-  expect(calledWithPayload.vercel.source).toEqual('lambda');
+  expect(calledWithPayload.vercel.source).toEqual('lambda-log');
 });


### PR DESCRIPTION
This PR provides 2 methods to facilitate logging HTTP requests.

The docs and examples have been updated to:
- Ask the users to create `middleware.ts` so that HTTP requests could be captured
- Encourage the users to create `error.tsx` to capture routing errors.

This will introduce new sources:
- middleware
- error.tsx



