### PR TITLE
fix(README.md): add missing ``` to code block ending

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ const logger = new Logger({
     console.log(event.message);
   },
 });
-
+```
 
 ### Capturing Errors
 


### PR DESCRIPTION
The README was missing a proper ending on a code block 😉