### PR TITLE
logger: provide new flag to enable Vercel log drain for API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ export default function ErrorPage({
 }
 ```
 
+## Improve API routes logging performance (Vercel)
+
+If you have Vercel's integration enabled and don't mind the log drain cost, you
+can make use of the log drain feature to send logs from API routes to Axiom.
+This would tell next-axiom to use `console.log()` to send logs to Vercel's log drain instead of sending the logs directly to Axiom and waiting for the logger's http flush request to complete.
+
+To enable this feature, set the `AXIOM_ENABLE_VERCEL_LOGDRAIN` environment variable to `true`.
+
 ## Upgrade to the App Router
 
 next-axiom switched to support the App Router starting with version 1.0. If you are upgrading a Pages Router app with next-axiom v0.x to the App Router, you will need to make the following changes:

--- a/examples/logger/app/api/edge/route.ts
+++ b/examples/logger/app/api/edge/route.ts
@@ -3,6 +3,10 @@ import { AxiomRequest, withAxiom } from 'next-axiom';
 export const runtime = 'edge';
 
 export const GET = withAxiom(async (req: AxiomRequest) => {
-  req.log.info('fired from edge route');
+  req.log.info('fired from edge route', {
+    method: req.method,
+    author: 'Islam Sheata',
+    purpose: 'testing',
+  });
   return new Response('Hello, Next.js!');
 });

--- a/examples/logger/app/api/lambda/route.ts
+++ b/examples/logger/app/api/lambda/route.ts
@@ -3,6 +3,10 @@ import { AxiomRequest, withAxiom } from 'next-axiom';
 export const runtime = 'nodejs';
 
 export const GET = withAxiom(async (req: AxiomRequest) => {
-  req.log.info('axiom lambda route');
+  req.log.info('axiom lambda route', {
+    method: req.method,
+    author: 'Islam Sheata',
+    purpose: 'testing',
+  });
   return new Response('Hello, Next.js!');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "use-deep-compare": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,8 @@ declare global {
 export const Version = require('../package.json').version;
 // detect if Vercel integration & logdrain is enabled
 export const isVercelIntegration = process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT || process.env.AXIOM_INGEST_ENDPOINT;
+export const enableMakeUseOfVercelLogdrain =
+  process.env.NEXT_PUBLIC_AXIOM_ENABLE_VERCEL_LOGDRAIN || process.env.AXIOM_ENABLE_VERCEL_LOGDRAIN;
 // detect if app is running on the Vercel platform
 export const isVercel = process.env.NEXT_PUBLIC_VERCEL || process.env.VERCEL;
 export const isNetlify = process.env.NETLIFY == 'true';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { config, isBrowser, isVercelIntegration, Version } from './config';
+import { config, isBrowser, isVercelIntegration, enableMakeUseOfVercelLogdrain, Version } from './config';
 import { NetlifyInfo } from './platform/netlify';
 import { isNoPrettyPrint, throttle } from './shared';
 
@@ -211,8 +211,12 @@ export class Logger {
     // if vercel integration is enabled, we can utilize the log drain
     // to send logs to Axiom without HTTP.
     // This saves resources and time on lambda and edge functions
-    if (isVercelIntegration && (this.config.source === 'edge-log' || this.config.source === 'lambda-log')) {
-      this.logEvents.forEach((ev) => console.log(JSON.stringify(ev)));
+    if (
+      isVercelIntegration &&
+      enableMakeUseOfVercelLogdrain &&
+      (this.config.source === 'edge-log' || this.config.source === 'lambda-log')
+    ) {
+      this.logEvents.forEach((ev) => console.log(ev));
       this.logEvents = [];
       return;
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -216,7 +216,7 @@ export class Logger {
       enableMakeUseOfVercelLogdrain &&
       (this.config.source === 'edge-log' || this.config.source === 'lambda-log')
     ) {
-      this.logEvents.forEach((ev) => console.log(ev));
+      this.logEvents.forEach((ev) => console.log(JSON.stringify(ev)));
       this.logEvents = [];
       return;
     }

--- a/tests/vercelConfig.test.ts
+++ b/tests/vercelConfig.test.ts
@@ -6,6 +6,7 @@ import { Logger } from '../src/logger';
 vi.hoisted(() => {
   process.env.NEXT_PUBLIC_AXIOM_URL = undefined;
   process.env.NEXT_PUBLIC_AXIOM_INGEST_ENDPOINT = 'https://api.axiom.co/v1/integrations/vercel';
+  process.env.AXIOM_ENABLE_VERCEL_LOGDRAIN = 'true';
 });
 
 test('reading vercel ingest endpoint', () => {
@@ -16,7 +17,7 @@ test('reading vercel ingest endpoint', () => {
   expect(url).toEqual('https://api.axiom.co/v1/integrations/vercel?type=logs');
 });
 
-test('logging to console when running on lambda', async () => {
+test('logging to console when running on vercel/lambda', async () => {
   vi.useFakeTimers();
   const mockedConsole = vi.spyOn(console, 'log');
   const time = new Date(Date.now()).toISOString();


### PR DESCRIPTION
This PR introduces a new flag `AXIOM_ENABLE_VERCEL_LOGDRAIN` to enable usage of Vercel's log drain for API routes. This could be considered a breaking change since now users will have to opt-in for this behavior by setting the new environment variable.


Closes #217 

