### PR TITLE
Dropped Vercel's log drain utilization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "use-deep-compare": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -208,15 +208,6 @@ export class Logger {
       return;
     }
 
-    // if vercel integration is enabled, we can utilize the log drain
-    // to send logs to Axiom without HTTP.
-    // This saves resources and time on lambda and edge functions
-    if (isVercelIntegration && (this.config.source === 'edge-log' || this.config.source === 'lambda-log')) {
-      this.logEvents.forEach((ev) => console.log(JSON.stringify(ev)));
-      this.logEvents = [];
-      return;
-    }
-
     const method = 'POST';
     const keepalive = true;
     const body = JSON.stringify(this.logEvents);


### PR DESCRIPTION
As the pricing of Vercel's log drain has gone higher, the  utilization for API routes doesn't make sense anymore.