### PR TITLE
feat: Add NEXT_PUBLIC_AXIOM_CUSTOM_ENDPOINT env

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -200,9 +200,15 @@ export class Logger {
       return;
     }
 
+    // To send logs over the network, we need one of:
+    //
+    // - Axiom URL and Axiom dataset and Axiom token
+    // - Axiom Vercel ingest URL
+    // - Custom endpoint
+    //
+    // We fall back to printing to console to avoid network errors in
+    // development environments.
     if (!config.isEnvVarsSet()) {
-      // if AXIOM ingesting url is not set, fallback to printing to console
-      // to avoid network errors in development environments
       this.logEvents.forEach((ev) => (this.config.prettyPrint ? this.config.prettyPrint(ev) : prettyPrint(ev)));
       this.logEvents = [];
       return;

--- a/src/platform/generic.ts
+++ b/src/platform/generic.ts
@@ -14,9 +14,10 @@ export default class GenericConfig implements Provider {
   environment: string = process.env.NODE_ENV;
   axiomUrl = process.env.NEXT_PUBLIC_AXIOM_URL || process.env.AXIOM_URL || 'https://api.axiom.co';
   region = process.env.REGION || undefined;
+  customEndpoint: string | undefined = process.env.NEXT_PUBLIC_AXIOM_CUSTOM_ENDPOINT;
 
   isEnvVarsSet(): boolean {
-    return !!(this.axiomUrl && this.dataset && this.token);
+    return !!(this.axiomUrl && this.dataset && this.token) || !!this.customEndpoint;
   }
 
   getIngestURL(_: EndpointType): string {
@@ -24,10 +25,18 @@ export default class GenericConfig implements Provider {
   }
 
   getLogsEndpoint(): string {
+    if (this.customEndpoint) {
+      return this.customEndpoint
+    }
+
     return isBrowser ? `${this.proxyPath}/logs` : this.getIngestURL(EndpointType.logs);
   }
 
   getWebVitalsEndpoint(): string {
+    if (this.customEndpoint) {
+      return this.customEndpoint
+    }
+
     return isBrowser ? `${this.proxyPath}/web-vitals` : this.getIngestURL(EndpointType.webVitals);
   }
 

--- a/src/platform/vercel.ts
+++ b/src/platform/vercel.ts
@@ -14,8 +14,8 @@ export default class VercelConfig extends GenericConfig implements Provider {
   token = undefined;
   axiomUrl = ingestEndpoint;
 
-  isEnvVarsSet (): boolean {
-    return ingestEndpoint != undefined && ingestEndpoint != '';
+  isEnvVarsSet(): boolean {
+    return (ingestEndpoint != undefined && ingestEndpoint != '') || !!this.customEndpoint;
   }
 
   getIngestURL(t: EndpointType) {
@@ -25,10 +25,18 @@ export default class VercelConfig extends GenericConfig implements Provider {
   }
 
   getWebVitalsEndpoint(): string {
+    if (this.customEndpoint) {
+      return this.customEndpoint
+    }
+
     return `${this.proxyPath}/web-vitals`;
   }
 
   getLogsEndpoint(): string {
+    if (this.customEndpoint) {
+      return this.customEndpoint
+    }
+
     return isBrowser ? `${this.proxyPath}/logs` : this.getIngestURL(EndpointType.logs);
   }
 


### PR DESCRIPTION
If this env is set, next-axiom will send logs and web-vitals to the given endpoint. This can be useful if you want to bring your own function.