### PR TITLE
feat: Add  `logRequestDetails` option to withAxiomRouteHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ export const GET = withAxiom((req: AxiomRequest) => {
 
 Route handlers accept a configuration object as the second argument. This object can contain the following properties:
 
-- `logReq`: Accepts a boolean or an array of keys. If you pass `true`, it will add the request details to the log (method, URL, headers, etc.). If you pass an array of strings, it will only add the specified keys. See [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request/url) and [NextRequest](https://nextjs.org/docs/app/api-reference/functions/next-request) for documentation on the available keys.
+- `logRequestDetails`: Accepts a boolean or an array of keys. If you pass `true`, it will add the request details to the log (method, URL, headers, etc.). If you pass an array of strings, it will only add the specified keys. See [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request/url) and [NextRequest](https://nextjs.org/docs/app/api-reference/functions/next-request) for documentation on the available keys.
 
 ```ts
 export const GET = withAxiom(
   async () => {
     return new Response("Hello World!");
   },
-  { logReq: ['body', 'nextUrl'] } // { logReq: true } is also valid
+  { logRequestDetails: ['body', 'nextUrl'] } // { logRequestDetails: true } is also valid
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ export const GET = withAxiom((req: AxiomRequest) => {
 });
 ```
 
+Route handlers also accept a configuration object as the second argument. This object can contain the following properties:
+
+- `details`: It accepts a boolean or an array of keys. If pass `true`, it will add the request details to the log (method, URL, headers, etc.). If you pass an array of strings, it will only log the specified keys.
+
+```ts
+export const GET = withAxiom(
+  async () => {
+    return new Response("Hello World!");
+  },
+  { details: ['body', 'nextUrl'] } // { details: true } is also valid
+);
+```
+
 ### Client components
 
 To send logs from client components, add `useLogger` from next-axiom to your component:

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ export const GET = withAxiom((req: AxiomRequest) => {
 
 Route handlers accept a configuration object as the second argument. This object can contain the following properties:
 
-- `details`: Accepts a boolean or an array of keys. If you pass `true`, it will add the request details to the log (method, URL, headers, etc.). If you pass an array of strings, it will only add the specified keys. See [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request/url) and [NextRequest](https://nextjs.org/docs/app/api-reference/functions/next-request) for documentation on the available keys.
+- `logReq`: Accepts a boolean or an array of keys. If you pass `true`, it will add the request details to the log (method, URL, headers, etc.). If you pass an array of strings, it will only add the specified keys. See [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request/url) and [NextRequest](https://nextjs.org/docs/app/api-reference/functions/next-request) for documentation on the available keys.
 
 ```ts
 export const GET = withAxiom(
   async () => {
     return new Response("Hello World!");
   },
-  { details: ['body', 'nextUrl'] } // { details: true } is also valid
+  { logReq: ['body', 'nextUrl'] } // { logReq: true } is also valid
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ export const GET = withAxiom((req: AxiomRequest) => {
 });
 ```
 
-Route handlers also accept a configuration object as the second argument. This object can contain the following properties:
+Route handlers accept a configuration object as the second argument. This object can contain the following properties:
 
-- `details`: It accepts a boolean or an array of keys. If pass `true`, it will add the request details to the log (method, URL, headers, etc.). If you pass an array of strings, it will only log the specified keys.
+- `details`: Accepts a boolean or an array of keys. If you pass `true`, it will add the request details to the log (method, URL, headers, etc.). If you pass an array of strings, it will only add the specified keys. See [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request/url) and [NextRequest](https://nextjs.org/docs/app/api-reference/functions/next-request) for documentation on the available keys.
 
 ```ts
 export const GET = withAxiom(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,7 +44,7 @@ export interface RequestReport {
   scheme: string;
   userAgent?: string | null;
   durationMs?: number;
-  details?: RequestJSON;
+  logReq?: RequestJSON;
 }
 
 export interface PlatformInfo {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { config, isBrowser, isVercelIntegration, Version } from './config';
 import { NetlifyInfo } from './platform/netlify';
 import { isNoPrettyPrint, throttle } from './shared';
+import { RequestJSON } from './withAxiom';
 
 const url = config.getLogsEndpoint();
 
@@ -43,6 +44,7 @@ export interface RequestReport {
   scheme: string;
   userAgent?: string | null;
   durationMs?: number;
+  details?: RequestJSON;
 }
 
 export interface PlatformInfo {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,7 +44,7 @@ export interface RequestReport {
   scheme: string;
   userAgent?: string | null;
   durationMs?: number;
-  logReq?: RequestJSON;
+  requestDetails?: RequestJSON;
 }
 
 export interface PlatformInfo {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -44,7 +44,7 @@ export interface RequestReport {
   scheme: string;
   userAgent?: string | null;
   durationMs?: number;
-  requestDetails?: RequestJSON;
+  details?: RequestJSON;
 }
 
 export interface PlatformInfo {

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -52,7 +52,6 @@ export interface RequestJSON {
   method: string;
   url: string;
   headers: Record<string, string>;
-  params: Record<string, string>;
   cookies: Record<string, string>;
   nextUrl?: {
     basePath: string;
@@ -111,12 +110,6 @@ export async function requestToJSON(request: Request | NextRequest): Promise<Req
   const headers: Record<string, string> = {};
   request.headers.forEach((value, key) => {
     headers[key] = value;
-  });
-
-  const url = new URL(request.url);
-  const params: Record<string, string> = {};
-  url.searchParams.forEach((value, key) => {
-    params[key] = value;
   });
 
   let cookiesData: Record<string, string> = {};
@@ -193,7 +186,6 @@ export async function requestToJSON(request: Request | NextRequest): Promise<Req
     method: request.method,
     url: request.url,
     headers,
-    params,
     cookies: cookiesData,
     nextUrl: nextUrlData,
     ip,

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -240,7 +240,7 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       scheme: req.url.split('://')[0],
       ip: req.headers.get('x-forwarded-for'),
       region,
-      logReq: Array.isArray(config?.logReq)
+      requestDetails: Array.isArray(config?.logReq)
         ? (Object.fromEntries(
             Object.entries(logReq as RequestJSON).filter(([key]) =>
               (config?.logReq as (keyof RequestJSON)[]).includes(key as keyof RequestJSON)

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -215,7 +215,7 @@ type NextHandler<T = any> = (
 ) => Promise<Response> | Promise<NextResponse> | NextResponse | Response;
 
 type AxiomRouteHandlerConfig = {
-  details?: boolean | (keyof RequestJSON)[];
+  logReq?: boolean | (keyof RequestJSON)[];
 };
 
 export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteHandlerConfig): NextHandler {
@@ -233,7 +233,7 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       pathname = new URL(req.url).pathname;
     }
 
-    const details = Array.isArray(config?.details) || config?.details === true ? await requestToJSON(req) : undefined;
+    const logReq = Array.isArray(config?.logReq) || config?.logReq === true ? await requestToJSON(req) : undefined;
 
     const report: RequestReport = {
       startTime: new Date().getTime(),
@@ -245,13 +245,13 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       scheme: req.url.split('://')[0],
       ip: req.headers.get('x-forwarded-for'),
       region,
-      details: Array.isArray(config?.details)
+      logReq: Array.isArray(config?.logReq)
         ? (Object.fromEntries(
-            Object.entries(details as RequestJSON).filter(([key]) =>
-              (config?.details as (keyof RequestJSON)[]).includes(key as keyof RequestJSON)
+            Object.entries(logReq as RequestJSON).filter(([key]) =>
+              (config?.logReq as (keyof RequestJSON)[]).includes(key as keyof RequestJSON)
             )
           ) as RequestJSON)
-        : details,
+        : logReq,
     };
 
     // main logger, mainly used to log reporting on the incoming HTTP request

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -210,7 +210,7 @@ type NextHandler<T = any> = (
 ) => Promise<Response> | Promise<NextResponse> | NextResponse | Response;
 
 type AxiomRouteHandlerConfig = {
-  logReq?: boolean | (keyof RequestJSON)[];
+  logRequestDetails?: boolean | (keyof RequestJSON)[];
 };
 
 export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteHandlerConfig): NextHandler {
@@ -228,7 +228,10 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       pathname = new URL(req.url).pathname;
     }
 
-    const logReq = Array.isArray(config?.logReq) || config?.logReq === true ? await requestToJSON(req) : undefined;
+    const requestDetails =
+      Array.isArray(config?.logRequestDetails) || config?.logRequestDetails === true
+        ? await requestToJSON(req)
+        : undefined;
 
     const report: RequestReport = {
       startTime: new Date().getTime(),
@@ -240,13 +243,13 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       scheme: req.url.split('://')[0],
       ip: req.headers.get('x-forwarded-for'),
       region,
-      requestDetails: Array.isArray(config?.logReq)
+      details: Array.isArray(config?.logRequestDetails)
         ? (Object.fromEntries(
-            Object.entries(logReq as RequestJSON).filter(([key]) =>
-              (config?.logReq as (keyof RequestJSON)[]).includes(key as keyof RequestJSON)
+            Object.entries(requestDetails as RequestJSON).filter(([key]) =>
+              (config?.logRequestDetails as (keyof RequestJSON)[]).includes(key as keyof RequestJSON)
             )
           ) as RequestJSON)
-        : logReq,
+        : requestDetails,
     };
 
     // main logger, mainly used to log reporting on the incoming HTTP request

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -321,14 +321,14 @@ function isNextConfig(param: WithAxiomParam): param is NextConfig {
 
 // withAxiom can be called either with NextConfig, which will add proxy rewrites
 // to improve deliverability of Web-Vitals and logs.
-export function withAxiom(param: NextHandler): NextHandler;
+export function withAxiom(param: NextHandler, config?: AxiomRouteHandlerConfig): NextHandler;
 export function withAxiom(param: NextConfig): NextConfig;
-export function withAxiom(param: WithAxiomParam) {
+export function withAxiom(param: WithAxiomParam, config?: AxiomRouteHandlerConfig) {
   if (typeof param == 'function') {
-    return withAxiomRouteHandler(param);
+    return withAxiomRouteHandler(param, config);
   } else if (isNextConfig(param)) {
     return withAxiomNextConfig(param);
   }
 
-  return withAxiomRouteHandler(param);
+  return withAxiomRouteHandler(param, config);
 }


### PR DESCRIPTION
This PR introduces an optional configuration object that contains a `logRequestDetails` property to specify if and whether to include detailed request information. 

Example of usage
```ts
export const GET = withAxiomRouteHandler(
  async () => {
    return new Response("Hello World!");
  },
  { logRequestDetails: true }
);
```
or 
```ts
export const GET = withAxiomRouteHandler(
  async () => {
    return new Response("Hello World!");
  },
  { logRequestDetails: ['body', 'nextUrl'] }
);
```