### PR TITLE
fix: remove edge reports in favor of vercel default reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "use-deep-compare": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -1,6 +1,6 @@
 import { NextConfig } from 'next';
 import { Rewrite } from 'next/dist/lib/load-custom-routes';
-import { config, isEdgeRuntime, isVercelIntegration } from './config';
+import { config, isEdgeRuntime } from './config';
 import { LogLevel, Logger, RequestReport } from './logger';
 import { type NextRequest, type NextResponse } from 'next/server';
 import { EndpointType, RequestJSON, requestToJSON } from './shared';
@@ -124,9 +124,6 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
 
       // flush the logger along with the child logger
       await logger.flush();
-      if (isEdgeRuntime && isVercelIntegration) {
-        logEdgeReport(report);
-      }
       return result;
     } catch (error: any) {
       report.endTime = new Date().getTime();
@@ -144,16 +141,9 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       log.attachResponseStatus(500);
 
       await logger.flush();
-      if (isEdgeRuntime && isVercelIntegration) {
-        logEdgeReport(report);
-      }
       throw error;
     }
   };
-}
-
-function logEdgeReport(report: RequestReport) {
-  console.log(`AXIOM_EDGE_REPORT::${JSON.stringify(report)}`);
 }
 
 type WithAxiomParam = NextConfig | NextHandler;


### PR DESCRIPTION
`AXIOM_EDGE_REPORT` doesn't seem to be needed anymore since reports for edge functions are now emitted correctly Vercel, this PR addresses that by removing the code associated with `AXIOM_EDGE_REPORT` also solves #171 