### PR TITLE
fix: webVitals duplicate info 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-axiom",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-axiom",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "use-deep-compare": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "next-axiom",
   "description": "Send WebVitals from your Next.js project to Axiom.",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/src/webVitals/index.ts
+++ b/src/webVitals/index.ts
@@ -7,14 +7,27 @@ export { AxiomWebVitals } from './components';
 
 export function useReportWebVitals(path?: string) {
   const pathName = usePathname();
+
+  /**
+   * Refs allows us to stabilize the path name so that we can properly stabilize the reportWebVitalsFn
+   */
+
   const stabilizedPath = useRef(path || pathName);
 
+  /**
+   * If the path changes, we update the stabilizedPath ref
+   */
   if (typeof path === 'string' && path !== stabilizedPath.current) {
     stabilizedPath.current = pathName;
   } else if (typeof path === 'string' && path === stabilizedPath.current) {
     stabilizedPath.current = path;
   }
 
+  /**
+   * Stabilizing the reportWebVitalsFn avoids reporting the same metrics from multiple paths, it happens because internally
+   * the useReportWebVitals from next uses a useEffect to report the metrics, and the reportWebVitalsFn is passed as a dependency
+   * to the useEffect, so when the path changes, the useEffect is re-run, and the same metrics are reported again.
+   */
   const reportWebVitalsFn: Parameters<typeof useNextReportWebVitals>[0] = useCallback(
     (metric) => reportWebVitalsWithPath(metric, stabilizedPath.current),
     []

--- a/src/webVitals/index.ts
+++ b/src/webVitals/index.ts
@@ -1,10 +1,24 @@
 import { usePathname } from 'next/navigation';
 import { useReportWebVitals as useNextReportWebVitals } from 'next/web-vitals';
 import { reportWebVitalsWithPath } from './webVitals';
+import { useCallback, useRef } from 'react';
 export { type WebVitalsMetric } from './webVitals';
-export { AxiomWebVitals } from './components'
+export { AxiomWebVitals } from './components';
 
 export function useReportWebVitals(path?: string) {
-    const pathName = usePathname();
-    useNextReportWebVitals((metric) => reportWebVitalsWithPath(metric, path || pathName));
+  const pathName = usePathname();
+  const stabilizedPath = useRef(path || pathName);
+
+  if (typeof path === 'string' && path !== stabilizedPath.current) {
+    stabilizedPath.current = pathName;
+  } else if (typeof path === 'string' && path === stabilizedPath.current) {
+    stabilizedPath.current = path;
+  }
+
+  const reportWebVitalsFn: Parameters<typeof useNextReportWebVitals>[0] = useCallback(
+    (metric) => reportWebVitalsWithPath(metric, stabilizedPath.current),
+    []
+  );
+
+  useNextReportWebVitals(reportWebVitalsFn);
 }


### PR DESCRIPTION
This PR stabilizes path in `useReportWebVitals` to only send metrics on hard navigation. 

Current implementation of `useReportWebVitals` get's triggered every time path changes without updating the vitals, this meant that vitals send were being duplicated on each soft navigation even though they are only measured on hard navigations, hence, we were seeing behaviors like the one reported on #234 

There seems to be [talks](https://developer.chrome.com/docs/web-platform/soft-navigations-experiment.) around having soft navigations registered for web vitals but there's no current implementation for it in `next/web-vitals.`