### PR TITLE
feat(logger): ensure error.cause is serialized

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -127,7 +127,7 @@ export class Logger {
 
     // check if passed args is an object, if its not an object, add it to fields.args
     if (args instanceof Error) {
-      logEvent.fields = { ...logEvent.fields, message: args.message, stack: args.stack, name: args.name };
+      logEvent.fields = { ...logEvent.fields, message: args.message, stack: args.stack, name: args.name, cause: args.cause };
     } else if (typeof args === 'object' && args !== null && Object.keys(args).length > 0) {
       const parsedArgs = JSON.parse(JSON.stringify(args, jsonFriendlyErrorReplacer));
       logEvent.fields = { ...logEvent.fields, ...parsedArgs };
@@ -353,6 +353,7 @@ function jsonFriendlyErrorReplacer(key: string, value: any) {
       name: value.name,
       message: value.message,
       stack: value.stack,
+      cause: jsonFriendlyErrorReplacer(undefined, value.cause),
     };
   }
 


### PR DESCRIPTION
I've just noticed that `error.cause` is not serialized when sending logs to axiom, this PR will correct that as I feel this is a pretty important part of the error to log.

What do you think?