### PR TITLE
Check NEXT_PUBLIC_VERCEL_ENV for platform metadata on Vercel config

### DIFF
--- a/src/platform/vercel.ts
+++ b/src/platform/vercel.ts
@@ -10,7 +10,7 @@ export default class VercelConfig extends GenericConfig implements Provider {
   provider = 'vercel';
   shouldSendEdgeReport = true;
   region = process.env.VERCEL_REGION || undefined;
-  environment = process.env.VERCEL_ENV || process.env.NODE_ENV || '';
+  environment = process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.VERCEL_ENV || process.env.NODE_ENV || '';
   token = undefined;
   axiomUrl = ingestEndpoint;
 


### PR DESCRIPTION
We noticed a bug that all client-side logs from our Vercel deployments are being sent with the metadata field vercel.env set to "production". This line looks to be the cause -- the Vercel config is only checking for the VERCEL_ENV environment variable, which isn't available in client components - so it falls back to the NODE_ENV which is "production" for both Vercel preview and production deployments. The corresponding client variable is NEXT_PUBLIC_VERCEL_ENV, so this PR changes the metadata to check for either NEXT_PUBLIC_VERCEL_ENV or VERCEL_ENV before falling back to NODE_ENV.