### PR TITLE
refactor(logger): implement dynamic logger flushing with error handling

### DIFF
--- a/src/withAxiom.ts
+++ b/src/withAxiom.ts
@@ -6,6 +6,20 @@ import { LogLevel, Logger, RequestReport } from './logger';
 import { type NextRequest, type NextResponse } from 'next/server';
 import { EndpointType, RequestJSON, requestToJSON } from './shared';
 
+// Helper function to handle logger flushing with dynamic waitUntil loading
+async function flushLogger(logger: Logger, showErrors?: boolean) {
+  const flushPromise = showErrors === true 
+    ? logger.flush() 
+    : logger.flush().catch(() => {});
+  
+  if (isVercel) {
+    const { waitUntil } = await import('@vercel/functions');
+    waitUntil(flushPromise);
+  } else {
+    await flushPromise;
+  }
+}
+
 export function withAxiomNextConfig(nextConfig: NextConfig): NextConfig {
   return {
     ...nextConfig,
@@ -60,6 +74,8 @@ type AxiomRouteHandlerConfig = {
   // override default log levels for notFound and redirect
   notFoundLogLevel?: LogLevel; // defaults to LogLevel.warn
   redirectLogLevel?: LogLevel; // defaults to LogLevel.info
+  // whether to show flush errors to users (defaults to false)
+  showErrors?: boolean;
 };
 
 export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteHandlerConfig): NextHandler {
@@ -131,11 +147,7 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       log.attachResponseStatus(result.status);
 
       // flush the logger along with the child logger
-      if (isVercel) {
-        waitUntil(logger.flush());
-      } else {
-        await logger.flush();
-      }
+      await flushLogger(logger, config?.showErrors);
       return result;
     } catch (error: any) {
       // capture request endTime first for more accurate reporting
@@ -181,11 +193,7 @@ export function withAxiomRouteHandler(handler: NextHandler, config?: AxiomRouteH
       log.log(logLevel, error.message, { error });
       log.attachResponseStatus(statusCode);
 
-      if (isVercel) {
-        waitUntil(logger.flush());
-      } else {
-        await logger.flush();
-      }
+      await flushLogger(logger, config?.showErrors);
       throw error;
     }
   };


### PR DESCRIPTION
When Axiom runs on Vercel, it can take advantage of waitUntil to avoid penalising the response time and flush the logger in the background.

On this PR:

-  Introduced the `showErrors` configuration option to control error visibility during logger flushing.
-  Added a helper function `flushLogger` to manage logger flushing based on the runtime environment (Vercel or not).
-  Updated the logger flush calls in route handlers to utilise the new `flushLogger` function, allowing for optional error display.