### PR TITLE
update nix shell to nodejs v20

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
 let pkgs = import <nixpkgs> {};
 in pkgs.mkShell {
-  nativeBuildInputs = [ pkgs.nodejs-16_x ];
+  nativeBuildInputs = [ pkgs.nodejs_20 ];
 }


### PR DESCRIPTION
nix package used in `shell.nix` nodejs-16_x is outdated, even using nodejs-18_x results in an error from nix:
```bash
error: Node.js 18.x has reached End-Of-Life and has been removed
```
so, moving into package `nodejs_20` seems reasonable if not already going to v22 and v24. and using v20 here is more reasonable than other options because we install types for it [here in `package.json`](https://github.com/axiomhq/next-axiom/blob/cab1e6eba4970613c241c6461d0ae11a22901ec5/package.json#L43C5-L43C30)

This change should result in developers feeling more comfortable about their dependencies while developing using nix shell.