### PR TITLE
feat: support withAxiom Configuration as a Function in next.config.ts

### DIFF
--- a/tests/withAxiom.test.ts
+++ b/tests/withAxiom.test.ts
@@ -55,3 +55,68 @@ test('withAxiom(NextConfig) with fallback rewrites (regression test for #21)', a
   });
   if (config.rewrites) await config.rewrites();
 });
+
+test('withAxiom(NextConfigFn) - function variant', async () => {
+  process.env.AXIOM_INGEST_ENDPOINT = 'http://localhost';
+
+  const configFn = (phase: string, { defaultConfig }: { defaultConfig: any }) => {
+    return {
+      reactStrictMode: true,
+      env: { PHASE: phase },
+    };
+  };
+
+  const wrappedConfigFn = withAxiom(configFn);
+  expect(wrappedConfigFn).toBeInstanceOf(Function);
+
+  // Call the wrapped function to ensure it works
+  const result = await wrappedConfigFn('phase-development-server', { defaultConfig: {} });
+  expect(result).toBeInstanceOf(Object);
+  expect(result.reactStrictMode).toBe(true);
+  expect(result.env?.PHASE).toBe('phase-development-server');
+  expect(result.rewrites).toBeInstanceOf(Function);
+});
+
+test('withAxiom(NextConfigFn) - async function variant', async () => {
+  process.env.AXIOM_INGEST_ENDPOINT = 'http://localhost';
+
+  const asyncConfigFn = async (phase: string, { defaultConfig }: { defaultConfig: any }) => {
+    return {
+      reactStrictMode: true,
+      env: { PHASE: phase },
+    };
+  };
+
+  const wrappedConfigFn = withAxiom(asyncConfigFn);
+  expect(wrappedConfigFn).toBeInstanceOf(Function);
+
+  // Call the wrapped function to ensure it works
+  const result = await wrappedConfigFn('phase-production-build', { defaultConfig: {} });
+  expect(result).toBeInstanceOf(Object);
+  expect(result.reactStrictMode).toBe(true);
+  expect(result.env?.PHASE).toBe('phase-production-build');
+  expect(result.rewrites).toBeInstanceOf(Function);
+});
+
+test('withAxiom(NextConfigFn) preserves existing rewrites', async () => {
+  process.env.AXIOM_INGEST_ENDPOINT = 'http://localhost';
+
+  const configFn = (phase: string, { defaultConfig }: { defaultConfig: any }) => {
+    return {
+      rewrites: async () => [
+        { source: '/old', destination: '/new' },
+      ],
+    };
+  };
+
+  const wrappedConfigFn = withAxiom(configFn);
+  const result = await wrappedConfigFn('phase-development-server', { defaultConfig: {} });
+  
+  const rewrites = await result.rewrites!();
+  // When original rewrites returns an array, axiom rewrites are concatenated
+  expect(Array.isArray(rewrites)).toBe(true);
+  const rewritesArray = rewrites as { source: string; destination: string }[];
+  // Should include original rewrite plus axiom rewrites
+  expect(rewritesArray.length).toBeGreaterThan(1);
+  expect(rewritesArray.some((r) => r.source === '/old')).toBe(true);
+});

--- a/tests/withAxiom.test.ts
+++ b/tests/withAxiom.test.ts
@@ -103,15 +103,13 @@ test('withAxiom(NextConfigFn) preserves existing rewrites', async () => {
 
   const configFn = (phase: string, { defaultConfig }: { defaultConfig: any }) => {
     return {
-      rewrites: async () => [
-        { source: '/old', destination: '/new' },
-      ],
+      rewrites: async () => [{ source: '/old', destination: '/new' }],
     };
   };
 
   const wrappedConfigFn = withAxiom(configFn);
   const result = await wrappedConfigFn('phase-development-server', { defaultConfig: {} });
-  
+
   const rewrites = await result.rewrites!();
   // When original rewrites returns an array, axiom rewrites are concatenated
   expect(Array.isArray(rewrites)).toBe(true);


### PR DESCRIPTION
`withAxiomNextConfig` now properly handles the [function variant of `next.config.js`](https://nextjs.org/docs/app/api-reference/config/next-config-js#configuration-as-a-function), which allows configs to be defined as:

```js
export default (phase, { defaultConfig }) => {
  return { /* config */ };
};
```

### Problem

Previously, `withAxiomNextConfig` only accepted object configs. This caused issues when composing with other Next.js config plugins (like `withWorkflow`) that may return or expect function configs.

Related issue: https://github.com/vercel/workflow/issues/262

### Changes

- Added type definitions for `NextConfigFn` and `NextConfigInput`
- Extracted rewrite logic into reusable `applyAxiomRewrites()` function
- Updated `withAxiomNextConfig` to wrap function configs, calling the original function then applying Axiom rewrites
- Added `isNextConfigFn` helper to distinguish between `NextConfigFn` (2 params: phase, context) and `NextHandler` (1-2 params: req, arg?)
- Added function overloads for proper TypeScript inference
- Shallow clone configs to avoid read-only property issues

### Usage

```js
// Object config (existing - still works)
export default withAxiom({
  reactStrictMode: true,
});

// Function config (now supported!)
export default withAxiom((phase, { defaultConfig }) => ({
  reactStrictMode: true,
}));

// Async function config (also supported!)
export default withAxiom(async (phase, { defaultConfig }) => ({
  /* config */
}));

// Composing with other plugins should now work in any order
export default withAxiom(withWorkflow(nextConfig));
export default withWorkflow(withAxiom(nextConfig));
```

### Testing

Added tests for:
- Sync function config variant
- Async function config variant  
- Preserving existing rewrites in function configs